### PR TITLE
return nil for relationships that exist but are empty

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    unit-ruby (0.1.3)
+    unit-ruby (0.1.4)
       faraday (~> 1.8.0)
 
 GEM

--- a/lib/unit-ruby/util/api_resource.rb
+++ b/lib/unit-ruby/util/api_resource.rb
@@ -85,7 +85,7 @@ module Unit
       class_name ||= resource_name.to_s.camelize
 
       define_method(resource_name) do
-        relationship_id = relationships[resource_name][:data]&.fetch(:id)
+        relationship_id = relationships.dig(resource_name, :data, :id)
 
         return nil unless relationship_id
 

--- a/lib/unit-ruby/version.rb
+++ b/lib/unit-ruby/version.rb
@@ -1,3 +1,3 @@
 module Unit
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Unit do
   it 'reutrns the correct version' do
-    expect(Unit::VERSION).to eq '0.1.3'
+    expect(Unit::VERSION).to eq '0.1.4'
   end
 end


### PR DESCRIPTION
in cases where a relationship is possible (e.g. an `ApplicationForm` can have an `Application`) but it doesn't exist for a specific instance, we should just return `nil` when trying to access that relationship (e.g. `application_form.application` should just return `nil` if there isn't an `Application`, instead of throwing an error), which is the behavior with ActiveRecord