### PR TITLE
Add `has_many` method to Ruby Unit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,4 +100,4 @@ DEPENDENCIES
   unit-ruby!
 
 BUNDLED WITH
-   1.17.2
+   2.2.11

--- a/lib/unit-ruby/deposit_account.rb
+++ b/lib/unit-ruby/deposit_account.rb
@@ -19,6 +19,7 @@ module Unit
     attribute :close_reason, Types::String, readonly: true # Optional. The reason the account was closed, either ByCustomer or Fraud.
 
     belongs_to :customer, class_name: 'Unit::IndividualCustomer'
+    has_many :customers, class_name: 'Unit::IndividualCustomer'
 
     include ResourceOperations::List
     include ResourceOperations::Create

--- a/lib/unit-ruby/deposit_account.rb
+++ b/lib/unit-ruby/deposit_account.rb
@@ -19,11 +19,26 @@ module Unit
     attribute :close_reason, Types::String, readonly: true # Optional. The reason the account was closed, either ByCustomer or Fraud.
 
     belongs_to :customer, class_name: 'Unit::IndividualCustomer'
+
+    # `has_many :customers` was added in order
+    # to support joint accounts.
+
     has_many :customers, class_name: 'Unit::IndividualCustomer'
 
     include ResourceOperations::List
     include ResourceOperations::Create
     include ResourceOperations::Save
     include ResourceOperations::Find
+
+    def self.add_customer(account_id, customer_id)
+      Unit::Connection.new.post(
+        "accounts/#{account_id}/relationships/customers",
+        {
+          data: [{ type: 'customer', id: customer_id }]
+        }
+      )
+
+      find(account_id)
+    end
   end
 end

--- a/lib/unit-ruby/version.rb
+++ b/lib/unit-ruby/version.rb
@@ -1,3 +1,3 @@
 module Unit
-  VERSION = '0.2.4'
+  VERSION = '0.2.5'
 end

--- a/spec/features/add_customer_spec.rb
+++ b/spec/features/add_customer_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+require 'securerandom'
+
+RSpec.describe Unit::DepositAccount do
+  before do
+    establish_connection_to_api!
+  end
+
+  let(:first_individual_customer) do
+    Factory.create_individual_customer
+  end
+
+  let(:second_individual_customer) do
+    Factory.create_individual_customer
+  end
+
+  let(:deposit_account) do
+    Unit::DepositAccount.create(
+      deposit_product: 'checking',
+      customer: first_individual_customer
+    )
+  end
+
+  it 'adds a new customer to the deposit account' do
+    account = Unit::DepositAccount.add_customer(
+      deposit_account.id,
+      second_individual_customer.id
+    )
+
+    expect(account.customers.length).to eq 2
+    expect(account.customers.map(&:id)).to eq [
+      first_individual_customer.id,
+      second_individual_customer.id
+
+    ]
+  end
+end

--- a/spec/features/deposit_account_spec.rb
+++ b/spec/features/deposit_account_spec.rb
@@ -25,5 +25,7 @@ RSpec.describe Unit::DepositAccount do
     expect(account.currency).to eq 'USD'
     expect(account.freeze_reason).to eq nil
     expect(account.close_reason).to eq nil
+
+    expect(account.customers.first.id).to eq customer.id
   end
 end


### PR DESCRIPTION
This PR adds a `has_many` method to the Ruby gem in order to return all customers that belong to a `deposit_account.` 

One question - Unit returns `customer` as a key on `resources` when there is only one customer & `customers` as a key when there is more than one customer. In this PR I made it so that `customers` is always returned, regardless of whether there is one or more customers. Do you think this is the appropriate solution? 

Please let me know if walking through this together would be helpful! 