### PR TITLE
Trevor/add joint account support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    unit-ruby (0.3.7)
+    unit-ruby (0.4.0)
       activesupport (>= 6.1.5, < 7.1.0)
       faraday (~> 1.8.0)
       faraday_middleware (~> 1.0.0)

--- a/lib/unit-ruby/util/api_resource.rb
+++ b/lib/unit-ruby/util/api_resource.rb
@@ -124,6 +124,16 @@ module Unit
           [send(singular_resource_name)].compact
         end
       end
+
+      define_method("#{resource_name}=") do |resources|
+        singular_resource_name = resource_name.to_s.singularize.to_sym
+
+        relationships[resource_name] = {
+          data: resources.map do |resource|
+            { type: singular_resource_name, id: resource.id }
+          end
+        }
+      end
     end
 
     # Hyrdates an instance of the resource from data returned from the API

--- a/lib/unit-ruby/version.rb
+++ b/lib/unit-ruby/version.rb
@@ -1,3 +1,3 @@
 module Unit
-  VERSION = '0.3.7'
+  VERSION = '0.4.0'
 end

--- a/spec/features/deposit_account_spec.rb
+++ b/spec/features/deposit_account_spec.rb
@@ -10,32 +10,61 @@ RSpec.describe Unit::DepositAccount do
     Factory.create_individual_customer
   end
 
-  it 'creates a deposit account for the customer' do
-    account = Unit::DepositAccount.create(deposit_product: 'checking', customer: customer)
+  context 'when creating an account for an individual customer' do
+    it 'creates a deposit account for the customer' do
+      account = Unit::DepositAccount.create(deposit_product: 'checking', customer: customer)
 
-    expect(account.id).to_not be nil
-    expect(account.customer.id).to eq customer.id
-    expect(account.status).to eq 'Open'
-    expect(account.routing_number).to_not be nil
-    expect(account.account_number).to_not be nil
-    expect(account.balance).to_not be nil
-    expect(account.hold).to_not be nil
-    expect(account.available).to_not be nil
-    expect(account.deposit_product).to eq 'checking'
-    expect(account.currency).to eq 'USD'
-    expect(account.freeze_reason).to eq nil
-    expect(account.close_reason).to eq nil
+      expect(account.id).to_not be nil
+      expect(account.customer.id).to eq customer.id
+      expect(account.status).to eq 'Open'
+      expect(account.routing_number).to_not be nil
+      expect(account.account_number).to_not be nil
+      expect(account.balance).to_not be nil
+      expect(account.hold).to_not be nil
+      expect(account.available).to_not be nil
+      expect(account.deposit_product).to eq 'checking'
+      expect(account.currency).to eq 'USD'
+      expect(account.freeze_reason).to eq nil
+      expect(account.close_reason).to eq nil
 
-    expect(account.customers.first.id).to eq customer.id
+      expect(account.customers.first.id).to eq customer.id
+    end
+
+    let(:deposit_account) do
+      Factory.create_deposit_account(customer)
+    end
+
+    it 'updates the deposit account information' do
+      deposit_account.save({ tags: { userId: 'new-user-id' } })
+      updated_deposit_account = Unit::DepositAccount.find(deposit_account.id)
+      expect(updated_deposit_account.tags[:user_id]).to eq('new-user-id')
+    end
   end
 
-  let(:deposit_account) do
-    Factory.create_deposit_account(customer)
-  end
+  context 'when creating a joing account' do
+    let(:another_customer) do
+      Factory.create_individual_customer
+    end
 
-  it 'updates the deposit account information' do
-    deposit_account.save({ tags: { userId: 'new-user-id' } })
-    updated_deposit_account = Unit::DepositAccount.find(deposit_account.id)
-    expect(updated_deposit_account.tags[:user_id]).to eq('new-user-id')
+    it 'creates a deposit account for both customers' do
+      account = Unit::DepositAccount.create(deposit_product: 'checking',
+                                            customers: [
+                                              customer, another_customer
+                                            ])
+      expect(account.id).to_not be nil
+      expect(account.customers.map(&:id)).to include(customer.id, another_customer.id)
+      expect(account.status).to eq 'Open'
+      expect(account.routing_number).to_not be nil
+      expect(account.account_number).to_not be nil
+      expect(account.balance).to_not be nil
+      expect(account.hold).to_not be nil
+      expect(account.available).to_not be nil
+      expect(account.deposit_product).to eq 'checking'
+      expect(account.currency).to eq 'USD'
+      expect(account.freeze_reason).to eq nil
+      expect(account.close_reason).to eq nil
+
+      expect(account.customers.first.id).to eq customer.id
+    end
   end
 end

--- a/spec/features/deposit_account_spec.rb
+++ b/spec/features/deposit_account_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Unit::DepositAccount do
     end
   end
 
-  context 'when creating a joing account' do
+  context 'when creating an account with multiple owners' do
     let(:another_customer) do
       Factory.create_individual_customer
     end

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 RSpec.describe Unit do
   it 'returns the correct version' do
-    expect(Unit::VERSION).to eq '0.3.7'
+    expect(Unit::VERSION).to eq '0.4.0'
   end
 end


### PR DESCRIPTION
Adds a setter method for `has_many` relationships. This enables us to create joint deposit accounts, instead of creating an individual deposit account and subsequently adding another user.