### PR TITLE
Relax activesupport dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,34 @@
 PATH
   remote: .
   specs:
-    unit-ruby (0.4.1)
-      activesupport (>= 6.1.5, < 7.1.0)
+    unit-ruby (0.4.2)
+      activesupport (>= 6, < 8)
       faraday (>= 2, < 3)
       faraday-retry (>= 2, < 3)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.4.3)
+    activesupport (7.1.3)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
     ast (2.4.2)
     base64 (0.2.0)
+    bigdecimal (3.1.6)
     coderay (1.1.3)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.2.3)
+    connection_pool (2.4.1)
     diff-lcs (1.5.0)
     dotenv (2.7.6)
+    drb (2.2.0)
+      ruby2_keywords
     faraday (2.8.1)
       base64
       faraday-net_http (>= 2.0, < 3.1)
@@ -27,10 +36,11 @@ GEM
     faraday-net_http (3.0.2)
     faraday-retry (2.2.0)
       faraday (~> 2.0)
-    i18n (1.12.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
-    minitest (5.18.0)
+    minitest (5.21.2)
+    mutex_m (0.2.0)
     parallel (1.21.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)

--- a/lib/unit-ruby/version.rb
+++ b/lib/unit-ruby/version.rb
@@ -1,3 +1,3 @@
 module Unit
-  VERSION = '0.4.1'
+  VERSION = '0.4.2'
 end

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 RSpec.describe Unit do
   it 'returns the correct version' do
-    expect(Unit::VERSION).to eq '0.4.1'
+    expect(Unit::VERSION).to eq '0.4.2'
   end
 end

--- a/unit-ruby.gemspec
+++ b/unit-ruby.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activesupport', '>= 6.1.5', '< 7.1.0'
+  spec.add_dependency 'activesupport', '>= 6', '< 8'
   spec.add_dependency 'faraday', '>= 2', '< 3'
   spec.add_dependency 'faraday-retry', '>= 2', '< 3'
 


### PR DESCRIPTION
Allow Rails 7.1 apps to use this gem