### PR TITLE
Add bank migration and related resources

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    unit-ruby (0.4.3)
+    unit-ruby (0.5.0)
       activesupport (>= 6.1.5, < 7.1.0)
       faraday (~> 1.8.0)
       faraday_middleware (~> 1.0.0)

--- a/lib/unit-ruby.rb
+++ b/lib/unit-ruby.rb
@@ -31,10 +31,13 @@ require 'unit-ruby/individual_application'
 require 'unit-ruby/individual_customer'
 require 'unit-ruby/individual_debit_card'
 require 'unit-ruby/institution'
+require 'unit-ruby/customer_bank_migration'
+require 'unit-ruby/outreach_settings'
 require 'unit-ruby/pin_status'
 require 'unit-ruby/statement'
 require 'unit-ruby/transaction'
 require 'unit-ruby/version'
+require 'unit-ruby/white_label_theme'
 
 module Unit
   # Usage:

--- a/lib/unit-ruby/customer_bank_migration.rb
+++ b/lib/unit-ruby/customer_bank_migration.rb
@@ -1,0 +1,22 @@
+module Unit
+  class CustomerBankMigration < APIResource
+    path '/migrations'
+
+    attribute :from_bank, Types::String
+    attribute :to_bank, Types::String
+    attribute :idempotency_key, Types::String
+    attribute :deadline, Types::Date
+    attribute :balance_transfer_timing, Types::String # Optional. The timing of the balance transfer. Default is "NewAccountCreation"
+    attribute :status, Types::String, readonly: true
+    attribute :migration_url, Types::String, readonly: true
+    attribute :created_at, Types::DateTime, readonly: true
+    attribute :updated_at, Types::DateTime, readonly: true
+
+    belongs_to :customer, class_name: 'Unit::IndividualCustomer'
+    belongs_to :white_label_theme, class_name: 'Unit::WhiteLabelTheme'
+    belongs_to :outreach_settings, class_name: 'Unit::OutreachSettings'
+
+    include ResourceOperations::Create
+    include ResourceOperations::Find
+  end
+end

--- a/lib/unit-ruby/outreach_settings.rb
+++ b/lib/unit-ruby/outreach_settings.rb
@@ -1,0 +1,4 @@
+module Unit
+  class OutreachSettings < APIResource
+  end
+end

--- a/lib/unit-ruby/util/api_resource.rb
+++ b/lib/unit-ruby/util/api_resource.rb
@@ -96,7 +96,7 @@ module Unit
 
       define_method("#{resource_name}=") do |resource|
         relationships[resource_name] = {
-          data: { type: resource_name, id: resource.id }
+          data: { type: resource_name.to_s.camelize(:lower).to_sym, id: resource.id }
         }
       end
     end

--- a/lib/unit-ruby/version.rb
+++ b/lib/unit-ruby/version.rb
@@ -1,3 +1,3 @@
 module Unit
-  VERSION = '0.4.3'
+  VERSION = '0.5.0'
 end

--- a/lib/unit-ruby/white_label_theme.rb
+++ b/lib/unit-ruby/white_label_theme.rb
@@ -1,0 +1,4 @@
+module Unit
+  class WhiteLabelTheme < APIResource
+  end
+end

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 RSpec.describe Unit do
   it 'returns the correct version' do
-    expect(Unit::VERSION).to eq '0.4.3'
+    expect(Unit::VERSION).to eq '0.5.0'
   end
 end


### PR DESCRIPTION
Adds the ability to `create` and `find` a `CustomerBankMigration`. In order to do this I needed to add OutreachSetting and WhiteLabelTheme resources so that they could be part of the `relationships` of the `CustomerBankMigration`