### PR TITLE
Add ability to fetch received payments from Unit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    unit-ruby (0.7.0)
+    unit-ruby (0.8.0)
       activesupport (>= 6.1.5, < 7.1.0)
       faraday (~> 1.8.0)
       faraday_middleware (~> 1.0.0)

--- a/lib/unit-ruby/received_payment.rb
+++ b/lib/unit-ruby/received_payment.rb
@@ -1,0 +1,30 @@
+module Unit
+  class ReceivedPayment < APIResource
+    path '/received-payments'
+
+    attribute :status, Types::String, readonly: true
+    attribute :direction, Types::String, readonly: true
+    attribute :was_advanced, Types::Boolean, readonly: true
+    attribute :is_advanceable, Types::Boolean, readonly: true
+    attribute :amount, Types::Integer, readonly: true
+    attribute :return_reason, Types::String, readonly: true
+    attribute :ach_return_reason, Types::String, readonly: true
+    attribute :completion_date, Types::DateTime, readonly: true
+    attribute :company_name, Types::String, readonly: true
+    attribute :counterparty_routing_number, Types::String, readonly: true
+    attribute :description, Types::String, readonly: true
+    attribute :addenda, Types::String, readonly: true
+    attribute :trace_number, Types::String, readonly: true
+    attribute :sec_code, Types::String, readonly: true
+    attribute :receiving_entity_name, Types::String, readonly: true
+    attribute :tags, Types::Hash # Optional
+
+    attribute :created_at, Types::DateTime, readonly: true
+
+    belongs_to :account, class_name: 'Unit::DepositAccount'
+    belongs_to :customer, class_name: 'Unit::IndividualCustomer'
+
+    include ResourceOperations::Find
+    include ResourceOperations::List
+  end
+end

--- a/lib/unit-ruby/version.rb
+++ b/lib/unit-ruby/version.rb
@@ -1,3 +1,3 @@
 module Unit
-  VERSION = '0.7.0'
+  VERSION = '0.8.0'
 end

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 RSpec.describe Unit do
   it 'returns the correct version' do
-    expect(Unit::VERSION).to eq '0.7.0'
+    expect(Unit::VERSION).to eq '0.8.0'
   end
 end


### PR DESCRIPTION
Adds [find](https://www.unit.co/docs/api/received-ach/#get-specific-received-payment) and [list](https://www.unit.co/docs/api/received-ach/#get-specific-received-payment) capabilities for the ReceivedPayments resource in Unit. ReceivedPayments are inbound ACH payment requests that can either be credits or debits to the recipient's account.

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExdm8zOWMwZGFqa3c5amY0cDMxbms1cXhkbm10ejF6OWt6dmh5ZXhsdSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/DxNB0G0kacs5eJoKS6/giphy.gif)