### PR TITLE
Add white label theme and language resource actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,6 +16,8 @@ on:
 env:
   UNIT_API_KEY: "${{secrets.UNIT_API_KEY}}"
   UNIT_BASE_URL: "${{secrets.UNIT_BASE_URL}}"
+  UNIT_THEME_ID: 55392
+  UNIT_LANGUAGE_ID: 14363
 
 jobs:
   test:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    unit-ruby (0.9.1)
+    unit-ruby (0.10.0)
       activesupport
       faraday (>= 2.0.1, < 3)
       faraday-retry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    unit-ruby (0.9.0)
+    unit-ruby (0.9.1)
       activesupport
       faraday (>= 2.0.1, < 3)
       faraday-retry
@@ -56,6 +56,8 @@ GEM
     rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
+    rspec-file_fixtures (0.1.9)
+      rspec (~> 3.12)
     rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
@@ -85,6 +87,7 @@ DEPENDENCIES
   pry
   rake (~> 13.0)
   rspec (~> 3.0)
+  rspec-file_fixtures (~> 0.1.9)
   rubocop (~> 1.24.1)
   unit-ruby!
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ end
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You will also need UNIT_THEME_ID and UNIT_LANGUAGE_ID set in your environment. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`.
 

--- a/lib/unit-ruby.rb
+++ b/lib/unit-ruby.rb
@@ -44,6 +44,7 @@ require 'unit-ruby/statement'
 require 'unit-ruby/transaction'
 require 'unit-ruby/version'
 require 'unit-ruby/white_label_theme'
+require 'unit-ruby/white_label_language'
 
 module Unit
   # Usage:

--- a/lib/unit-ruby/util/connection.rb
+++ b/lib/unit-ruby/util/connection.rb
@@ -24,7 +24,11 @@ module Unit
     #
     # @return the resource (or array of resources) returned from the API
     def get(path, params = nil)
-      response = connection.get(path, params)
+      response = connection.get do |req|
+        req.url path
+        req.headers['Content-Type'] = 'application/vnd.api+json'
+        req.params = params if params
+      end
 
       handle_errors(response)
 
@@ -52,6 +56,19 @@ module Unit
         req.url path
         req.headers['Content-Type'] = 'application/vnd.api+json'
         req.body = data.deep_transform_keys! { |key| key.to_s.camelize(:lower) } if data
+      end
+
+      handle_errors(response)
+
+      from_json_api(response.body)
+    end
+
+    # Executes a PUT of a JSON object without transforming the keys
+    def put_json(path, data = nil)
+      response = connection.put do |req|
+        req.url path
+        req.headers['Content-Type'] = 'application/vnd.api+json'
+        req.body = data.deep_transform_keys!(&:to_s) if data
       end
 
       handle_errors(response)

--- a/lib/unit-ruby/util/resource_operations.rb
+++ b/lib/unit-ruby/util/resource_operations.rb
@@ -77,5 +77,25 @@ module Unit
         update_resource_from_json_api(updated_resource)
       end
     end
+
+    # Replace the entire resource, instead of only patching dirty attributes
+    module Replace
+      def replace(attributes)
+        updated_resource = self.class.connection.put(
+          self.class.resource_path(id),
+          {
+            data: {
+              type: resource_type,
+              attributes: attributes
+            }
+          }
+        )
+        update_resource_from_json_api(updated_resource)
+      end
+
+      def replace_json(json_attributes)
+        replace(JSON.parse(json_attributes))
+      end
+    end
   end
 end

--- a/lib/unit-ruby/version.rb
+++ b/lib/unit-ruby/version.rb
@@ -1,3 +1,3 @@
 module Unit
-  VERSION = '0.9.0'
+  VERSION = '0.9.1'
 end

--- a/lib/unit-ruby/version.rb
+++ b/lib/unit-ruby/version.rb
@@ -1,3 +1,3 @@
 module Unit
-  VERSION = '0.9.1'
+  VERSION = '0.10.0'
 end

--- a/lib/unit-ruby/white_label_language.rb
+++ b/lib/unit-ruby/white_label_language.rb
@@ -1,6 +1,6 @@
 module Unit
-  class WhiteLabelTheme < APIResource
-    path '/white-label/theme'
+  class WhiteLabelLanguage < APIResource
+    path '/white-label/language'
 
     def save_config(config_json)
       updated_resource = self.class.connection.put_json(

--- a/lib/unit-ruby/white_label_language.rb
+++ b/lib/unit-ruby/white_label_language.rb
@@ -2,20 +2,8 @@ module Unit
   class WhiteLabelLanguage < APIResource
     path '/white-label/language'
 
-    def save_config(config_json)
-      updated_resource = self.class.connection.put_json(
-        self.class.resource_path(id),
-        {
-          data: {
-            type: resource_type,
-            attributes: config_json
-          }
-        }
-      )
-      update_resource_from_json_api(updated_resource)
-    end
-
     include ResourceOperations::List
     include ResourceOperations::Find
+    include ResourceOperations::Replace
   end
 end

--- a/lib/unit-ruby/white_label_theme.rb
+++ b/lib/unit-ruby/white_label_theme.rb
@@ -2,20 +2,8 @@ module Unit
   class WhiteLabelTheme < APIResource
     path '/white-label/theme'
 
-    def save_config(config_json)
-      updated_resource = self.class.connection.put_json(
-        self.class.resource_path(id),
-        {
-          data: {
-            type: resource_type,
-            attributes: config_json
-          }
-        }
-      )
-      update_resource_from_json_api(updated_resource)
-    end
-
     include ResourceOperations::List
     include ResourceOperations::Find
+    include ResourceOperations::Replace
   end
 end

--- a/spec/features/white_label_language_spec.rb
+++ b/spec/features/white_label_language_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+RSpec.describe Unit::WhiteLabelLanguage do
+  before do
+    establish_connection_to_api!
+  end
+
+  after do
+    Unit::WhiteLabelLanguage
+      .find(ENV.fetch('UNIT_LANGUAGE_ID'))
+      .save_config(JSON.parse(fixture('language_initial.json').read))
+  end
+
+  it 'updates a language' do
+    language = Unit::WhiteLabelLanguage.find(ENV.fetch('UNIT_LANGUAGE_ID', nil))
+    initial_language_configuration = language.raw_data[:attributes]
+
+    expect(initial_language_configuration[:name]).to eq('Unit-Ruby Specs English Language Config')
+    expect(initial_language_configuration[:global][:months]).to eq(
+      january: 'January',
+      february: 'February',
+      march: 'March',
+      april: 'April',
+      may: 'May',
+      june: 'June',
+      july: 'July',
+      august: 'August',
+      september: 'September',
+      october: 'October',
+      november: 'November',
+      december: 'December'
+    )
+
+    language.save_config(JSON.parse(fixture('language_updated.json').read))
+
+    language = Unit::WhiteLabelLanguage.find(ENV.fetch('UNIT_LANGUAGE_ID', nil))
+    updated_language_configuration = language.raw_data[:attributes]
+
+    expect(updated_language_configuration[:name]).to eq(
+      'Unit-Ruby Specs Updated English Language Config'
+    )
+    expect(updated_language_configuration[:global][:months]).to eq(
+      january: 'Janyary',
+      february: 'Febby',
+      march: 'Myarsh',
+      april: 'Ahpreel',
+      may: 'Meje',
+      june: 'Joone',
+      july: 'Judy',
+      august: 'Aygist',
+      september: 'Septebber',
+      october: 'Octopus',
+      november: 'Novii',
+      december: 'Decembah'
+    )
+  end
+end

--- a/spec/features/white_label_language_spec.rb
+++ b/spec/features/white_label_language_spec.rb
@@ -5,41 +5,43 @@ RSpec.describe Unit::WhiteLabelLanguage do
     establish_connection_to_api!
   end
 
-  after do
-    Unit::WhiteLabelLanguage
-      .find(ENV.fetch('UNIT_LANGUAGE_ID'))
-      .save_config(JSON.parse(fixture('language_initial.json').read))
+  def update_language(fixture_name)
+    Unit::WhiteLabelLanguage.find(ENV.fetch('UNIT_LANGUAGE_ID')).tap do |language|
+      language.replace_json(
+        fixture(fixture_name).read
+      )
+    end
   end
 
   it 'updates a language' do
-    language = Unit::WhiteLabelLanguage.find(ENV.fetch('UNIT_LANGUAGE_ID', nil))
-    initial_language_configuration = language.raw_data[:attributes]
+    initial_language = update_language('language_initial.json')
+    initial_language_attributes = initial_language.raw_data[:attributes]
 
-    expect(initial_language_configuration[:name]).to eq('Unit-Ruby Specs English Language Config')
-    expect(initial_language_configuration[:global][:months]).to eq(
-      january: 'January',
-      february: 'February',
-      march: 'March',
-      april: 'April',
-      may: 'May',
-      june: 'June',
-      july: 'July',
-      august: 'August',
-      september: 'September',
-      october: 'October',
-      november: 'November',
-      december: 'December'
-    )
+    expect(initial_language_attributes[:name])
+      .to eq('Unit-Ruby Specs English Language Config')
+    expect(initial_language_attributes[:global][:months])
+      .to eq(
+        january: 'January',
+        february: 'February',
+        march: 'March',
+        april: 'April',
+        may: 'May',
+        june: 'June',
+        july: 'July',
+        august: 'August',
+        september: 'September',
+        october: 'October',
+        november: 'November',
+        december: 'December'
+      )
 
-    language.save_config(JSON.parse(fixture('language_updated.json').read))
+    updated_language = update_language('language_updated.json')
+    updated_language_attributes = updated_language.raw_data[:attributes]
 
-    language = Unit::WhiteLabelLanguage.find(ENV.fetch('UNIT_LANGUAGE_ID', nil))
-    updated_language_configuration = language.raw_data[:attributes]
-
-    expect(updated_language_configuration[:name]).to eq(
+    expect(updated_language_attributes[:name]).to eq(
       'Unit-Ruby Specs Updated English Language Config'
     )
-    expect(updated_language_configuration[:global][:months]).to eq(
+    expect(updated_language_attributes[:global][:months]).to eq(
       january: 'Janyary',
       february: 'Febby',
       march: 'Myarsh',

--- a/spec/features/white_label_theme_spec.rb
+++ b/spec/features/white_label_theme_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe Unit::WhiteLabelTheme do
+  before do
+    establish_connection_to_api!
+  end
+
+  after do
+    Unit::WhiteLabelTheme
+      .find(ENV.fetch('UNIT_THEME_ID'))
+      .save_config(JSON.parse(fixture('theme_initial.json').read))
+  end
+
+  it 'updates a theme' do
+    theme = Unit::WhiteLabelTheme.find(ENV.fetch('UNIT_THEME_ID', nil))
+    initial_theme_configuration = theme.raw_data[:attributes]
+
+    expect(initial_theme_configuration[:name]).to eq('Unit-Ruby Specs Default Theme')
+    expect(initial_theme_configuration[:global][:logo_url]).to eq('https://app.s.unit.sh/logo-dark.f1c96208.svg')
+
+    theme.save_config(JSON.parse(fixture('theme_updated.json').read))
+
+    theme = Unit::WhiteLabelTheme.find(ENV.fetch('UNIT_THEME_ID', nil))
+    updated_theme_configuration = theme.raw_data[:attributes]
+
+    expect(updated_theme_configuration[:name]).to eq('Unit-Ruby Specs Updated Theme')
+    expect(updated_theme_configuration[:global][:logo_url]).to eq('https://some-other-logo.svg')
+  end
+end

--- a/spec/features/white_label_theme_spec.rb
+++ b/spec/features/white_label_theme_spec.rb
@@ -5,25 +5,29 @@ RSpec.describe Unit::WhiteLabelTheme do
     establish_connection_to_api!
   end
 
-  after do
-    Unit::WhiteLabelTheme
-      .find(ENV.fetch('UNIT_THEME_ID'))
-      .save_config(JSON.parse(fixture('theme_initial.json').read))
+  def update_theme(fixture_name)
+    Unit::WhiteLabelTheme.find(ENV.fetch('UNIT_THEME_ID')).tap do |theme|
+      theme.replace_json(
+        fixture(fixture_name).read
+      )
+    end
   end
 
   it 'updates a theme' do
-    theme = Unit::WhiteLabelTheme.find(ENV.fetch('UNIT_THEME_ID', nil))
-    initial_theme_configuration = theme.raw_data[:attributes]
+    initial_theme = update_theme('theme_initial.json')
+    initial_theme_attributes = initial_theme.raw_data[:attributes]
 
-    expect(initial_theme_configuration[:name]).to eq('Unit-Ruby Specs Default Theme')
-    expect(initial_theme_configuration[:global][:logo_url]).to eq('https://app.s.unit.sh/logo-dark.f1c96208.svg')
+    expect(initial_theme_attributes[:name])
+      .to eq('Unit-Ruby Specs Default Theme')
+    expect(initial_theme_attributes[:global][:logo_url])
+      .to eq('https://app.s.unit.sh/logo-dark.f1c96208.svg')
 
-    theme.save_config(JSON.parse(fixture('theme_updated.json').read))
+    updated_theme = update_theme('theme_updated.json')
+    updated_theme_attributes = updated_theme.raw_data[:attributes]
 
-    theme = Unit::WhiteLabelTheme.find(ENV.fetch('UNIT_THEME_ID', nil))
-    updated_theme_configuration = theme.raw_data[:attributes]
-
-    expect(updated_theme_configuration[:name]).to eq('Unit-Ruby Specs Updated Theme')
-    expect(updated_theme_configuration[:global][:logo_url]).to eq('https://some-other-logo.svg')
+    expect(updated_theme_attributes[:name])
+      .to eq('Unit-Ruby Specs Updated Theme')
+    expect(updated_theme_attributes[:global][:logo_url])
+      .to eq('https://some-other-logo.svg')
   end
 end

--- a/spec/fixtures/language_initial.json
+++ b/spec/fixtures/language_initial.json
@@ -1,0 +1,974 @@
+{
+    "name": "Unit-Ruby Specs English Language Config",
+    "global": {
+      "days": {
+        "yesterday": "Yesterday",
+        "today": "Today"
+      },
+      "toasts": {
+        "copy": "Copied"
+      },
+      "months": {
+        "january": "January",
+        "february": "February",
+        "march": "March",
+        "april": "April",
+        "may": "May",
+        "june": "June",
+        "july": "July",
+        "august": "August",
+        "september": "September",
+        "october": "October",
+        "november": "November",
+        "december": "December"
+      },
+      "states": {
+        "AL": "Alabama",
+        "AK": "Alaska",
+        "AZ": "Arizona",
+        "AR": "Arkansas",
+        "CA": "California",
+        "CO": "Colorado",
+        "CT": "Connecticut",
+        "DE": "Delaware",
+        "DC": "District Of Columbia",
+        "FL": "Florida",
+        "GA": "Georgia",
+        "HI": "Hawaii",
+        "ID": "Idaho",
+        "IL": "Illinois",
+        "IN": "Indiana",
+        "IA": "Iowa",
+        "KS": "Kansas",
+        "KY": "Kentucky",
+        "LA": "Louisiana",
+        "ME": "Maine",
+        "MD": "Maryland",
+        "MA": "Massachusetts",
+        "MI": "Michigan",
+        "MN": "Minnesota",
+        "MS": "Mississippi",
+        "MO": "Missouri",
+        "MT": "Montana",
+        "NE": "Nebraska",
+        "NV": "Nevada",
+        "NH": "New Hampshire",
+        "NJ": "New Jersey",
+        "NM": "New Mexico",
+        "NY": "New York",
+        "NC": "North Carolina",
+        "ND": "North Dakota",
+        "OH": "Ohio",
+        "OK": "Oklahoma",
+        "OR": "Oregon",
+        "PA": "Pennsylvania",
+        "RI": "Rhode Island",
+        "SC": "South Carolina",
+        "SD": "South Dakota",
+        "TN": "Tennessee",
+        "TX": "Texas",
+        "UT": "Utah",
+        "VT": "Vermont",
+        "VA": "Virginia",
+        "WA": "Washington",
+        "WV": "West Virginia",
+        "WI": "Wisconsin",
+        "WY": "Wyoming"
+      },
+      "accountPurpose": {
+        "taxes": "taxes",
+        "saving": "saving",
+        "savings": "savings",
+        "generic": "generic",
+        "account": "account",
+        "checking": "checking",
+        "expenses": "expenses",
+        "spending": "spending"
+      }
+    },
+    "elementsCard": {
+      "title": {
+        "virtual": "Virtual Card {{cardNumberLast4Digits}}",
+        "physical": "Physical Card {{cardNumberLast4Digits}}"
+      },
+      "goodThru": "GOOD \n THRU",
+      "types": {
+        "debit": "Debit",
+        "credit": "Credit",
+        "individual": "Individual",
+        "business": "Business",
+        "virtual": "Virtual",
+        "physical": "Physical"
+      },
+      "statuses": {
+        "lost": "Lost",
+        "active": "Active",
+        "stolen": "Stolen",
+        "frozen": "Frozen",
+        "inactive": "Inactive",
+        "closedByCustomer": "Closed",
+        "suspectedFraud": "Disabled"
+      },
+      "sensitiveDataButton": {
+        "show": "Show Details",
+        "hide": "Hide Details"
+      },
+      "menuItems": {
+        "title": "Manage Card",
+        "freeze": "Freeze",
+        "close": "Close Card",
+        "unfreeze": "Unfreeze",
+        "managePin": "Manage PIN",
+        "replace": "Replace Card",
+        "lostOrStolen": "Report Lost or Stolen",
+        "addToWallet": "Manage {{walletName}} Wallet"
+      },
+      "actions": {
+        "common": {
+          "proceedButton": "Proceed",
+          "backButton": "Back",
+          "errorResponse": {
+            "title": "Something went wrong",
+            "description": "Please try again later"
+          }
+        },
+        "activate": {
+          "overlayButton": "Activate",
+          "form": {
+            "flowTitle": "Card Activation",
+            "mainTitle": "Activate your card",
+            "description": "Provide your card details below",
+            "expirationDate": {
+              "label": "Expiration Date",
+              "errorMessages": {
+                "required": "Required",
+                "expirationDate": "The expiration date is invalid"
+              }
+            },
+            "cvv2": {
+              "label": "CVV2",
+              "errorMessages": {
+                "required": "Required",
+                "securityCode": "The security code is invalid"
+              }
+            }
+          },
+          "response": {
+            "title": "The card has been activated",
+            "description": "Taking you to set up your Pin"
+          }
+        },
+        "freeze": {
+          "flowTitle": "Freeze card",
+          "mainTitle": "Are you sure you want to freeze this card?",
+          "description": "You won’t be able to use your card while it is frozen, but you can unfreeze it at any time."
+        },
+        "unfreeze": {
+          "flowTitle": "Unfreeze card",
+          "mainTitle": "Are you sure you want to unfreeze this card?"
+        },
+        "managePin": {
+          "flowTitle": "Manage PIN",
+          "setPin": {
+            "mainTitle": "Set your new card PIN",
+            "enterPin": {
+              "label": "Enter a four digit PIN code",
+              "errorMessages": {
+                "required": "Required",
+                "pattern": "Make sure the PIN includes digits only"
+              }
+            },
+            "reenterPin": {
+              "label": "Validate PIN",
+              "errorMessages": {
+                "required": "Required",
+                "pattern": "Make sure the PIN includes digits only",
+                "comparison": "Make sure to enter the same PIN number"
+              }
+            },
+            "response": {
+              "title": "Your card PIN is set",
+              "description": "Your card is ready for use"
+            }
+          },
+          "changePin": {
+            "mainTitle": "Change your PIN",
+            "currentPin": {
+              "label": "Your current PIN",
+              "errorMessages": {
+                "required": "Required",
+                "pattern": "Make sure the PIN includes digits only"
+              }
+            },
+            "newPin": {
+              "label": "New PIN code",
+              "errorMessages": {
+                "required": "Required",
+                "pattern": "Make sure the PIN includes digits only"
+              }
+            },
+            "newPinConfirm": {
+              "label": "Confirm new PIN",
+              "errorMessages": {
+                "required": "Required",
+                "pattern": "Make sure the PIN includes digits only",
+                "comparison": "Make sure to enter the same PIN number"
+              }
+            },
+            "response": {
+              "title": "Your card PIN is set"
+            }
+          }
+        },
+        "replace": {
+          "flowTitle": "Replace card",
+          "mainTitle": "Confirm shipping address",
+          "description": "Your card will be shipped to this address in 5-7 business days",
+          "formButton": "Change address",
+          "form": {
+            "title": "Update your shipping address",
+            "subtitle": "Your card will be shipped to this address in 5-7 business days",
+            "submitButton": "Confirm address",
+            "street": {
+              "label": "Street address",
+              "errorMessages": {
+                "required": "Please enter your street address"
+              }
+            },
+            "street2": {
+              "label": "Apt, Suite, Unit"
+            },
+            "city": {
+              "label": "City",
+              "errorMessages": {
+                "required": "Please enter your city"
+              }
+            },
+            "state": {
+              "label": "State",
+              "errorMessages": {
+                "required": "Please select your state"
+              }
+            },
+            "postalCode": {
+              "label": "Zip code",
+              "errorMessages": {
+                "required": "Please enter your zip code",
+                "pattern": "Zip code must be 5 or 9 digits long"
+              }
+            }
+          },
+          "response": {
+            "title": "Your replacement card is on the way",
+            "description": "Expect your card to arrive in 5-7 business days"
+          }
+        },
+        "report": {
+          "flowTitle": "Report card",
+          "mainTitle": "Report card ending with {{maskedCardNumberLast4Digits}}",
+          "description": "What happened to your card?",
+          "confirmationTitle": "Are you sure you want to report this card?",
+          "confirmationDescription": "Reporting your card will close it permanently.",
+          "radioButtons": {
+            "lost": "My card was lost",
+            "stolen": "My card was stolen"
+          },
+          "admonition": {
+            "description": "A Lost or Stolen card will be permanently closed.",
+            "link": "Learn more"
+          },
+          "response": {
+            "title": "Your card was closed",
+            "description": {
+              "lost": "Your card was reported Lost and you won't be able to make transactions using it",
+              "stolen": "Your card was reported Stolen and you won't be able to make transactions using it"
+            }
+          }
+        },
+        "close": {
+          "flowTitle": "Close card",
+          "mainTitle": "Are you sure you want to close card ending with {{maskedCardNumberLast4Digits}}?",
+          "description": "You won't be able to activate this card later",
+          "admonition": {
+            "description": "Closing this card is permanent and cannot be reversed.",
+            "link": "Learn more"
+          },
+          "response": {
+            "title": "Your card is closed",
+            "description": "It can no longer be used"
+          }
+        },
+        "addToWallet": {
+          "flowTitle": "Mobile wallet",
+          "mainTitle": "Add your card to {{walletName}} wallet",
+          "description": "Add your card for easy payment with the wallet app anywhere.",
+          "response": {
+            "title": "Your card was successfully added to {{walletName}} wallet"
+          }
+        }
+      }
+    },
+    "elementsAccount": {
+      "title": "{{accountPurposeWords}} {{maskedAccountNumber}}",
+      "availableBalance": "Available Balance",
+      "creditBalance": "Credit Balance",
+      "accountActions": {
+        "title": "Account Actions",
+        "accountDetails": "Account Details",
+        "accountStatements": "Account Statements",
+        "bankVerificationLetter": "Bank Verification Letter"
+      },
+      "accountDetails": {
+        "title": "Account {{maskedAccountNumber}}",
+        "subtitle": "{{accountName}}",
+        "accountOwner": "Account owner",
+        "accountNumber": "Account number",
+        "accountRoutingNumber": "Routing number",
+        "accountPurpose": "Account Purpose",
+        "bank": "Bank"
+      },
+      "accountStatements": {
+        "title": "Account Statements",
+        "subtitle": "Download account statement for account ending with #{{accountNumberLast4Digits}}",
+        "downloadStatementButton": "Save Statement",
+        "downloadStatementErrorMessage": "Download failed , try again later",
+        "emptyStatementsMessage": "There are no account statements available"
+      },
+      "accountList": {
+        "title": "Switch Account",
+        "accountTitle": "{{accountPurposeWords}} {{maskedAccountNumber}}",
+        "accountSubtitle": "{{accountName}}"
+      }
+    },
+    "elementsAchDebit": {
+      "flowTitle": "Fund my account",
+      "accountsListStage": {
+        "title": "Pull funds to",
+        "listTitle": "Select destination account",
+        "backButton": "Back",
+        "destination": "Destination account"
+      },
+      "counterpartiesListStage": {
+        "title": "Pull funds from",
+        "addButton": "New account"
+      },
+      "emptyListStage": {
+        "title": "Pull funds from",
+        "nextButton": "Connect New Account",
+        "message": {
+          "title": "Connect your first account",
+          "subtitle": "Log in instantly and securely to your accounts, no matter in which bank. This will allow you to transfer money and fund your account"
+        }
+      },
+      "counterpartyAddedStage": {
+        "successMessage": {
+          "firstLine": "New account was",
+          "secondLine": "connected successfully!"
+        }
+      },
+      "enterAmountStage": {
+        "title": "New transfer",
+        "nextButton": "Continue",
+        "backButton": "Back",
+        "input": {
+          "title": "Amount"
+        }
+      },
+      "reviewStage": {
+        "title": "Review transfer",
+        "nextButton": "Complete payment",
+        "backButton": "Back",
+        "footnote": {
+          "regularText": "Funds will be available",
+          "boldText": "in 1-3 business days"
+        },
+        "descriptionList": {
+          "amount": "Amount",
+          "fee": "Fee",
+          "date": "Transaction Date"
+        },
+        "input": {
+          "label": "Description (optional)",
+          "note": "Visible to the recipient"
+        }
+      },
+      "completedStage": {
+        "messages": {
+          "pendingMessage": {
+            "title": "Account funded with ${{amount}}",
+            "subtitle": "Transfer expected by {{date}}"
+          },
+          "errorMessage": {
+            "title": "Something went wrong",
+            "subtitle": "Please try again later"
+          },
+          "rejectedMessages": {
+            "title": "The transfer could not be sent",
+            "subtitle": {
+              "accountClosed": "The recipient's account has been closed",
+              "accountFrozen": "The recipient's account has been frozen",
+              "insufficientFunds": "The recipient's account has insufficient funds"
+            }
+          }
+        }
+      }
+    },
+    "elementsAchCredit": {
+      "flowTitle": "",
+      "accountsListStage": {
+        "title": "Send payment from"
+      },
+      "counterpartiesListStage": {
+        "title": "Send payment to",
+        "backButton": "Back",
+        "listTitle": "Select destination recipient",
+        "addButton": "New recipient",
+        "destination": "Destination recipient"
+      },
+      "emptyListStage": {
+        "title": "Send payment to",
+        "nextButton": "Add New Recipient",
+        "backButton": "Back",
+        "destination": "Destination recipient",
+        "message": {
+          "title": "You haven’t added any recipients",
+          "subtitle": "Easily add your first recipient and transfer money easily & quickly"
+        }
+      },
+      "addNewCounterpartyStage": {
+        "title": "New recipient",
+        "nextButton": "Continue",
+        "backButton": "Back",
+        "form": {
+          "fullName": {
+            "label": "Full Name",
+            "errorMessages": {
+              "minLength": "Full name must contain at least 2 letters",
+              "required": "Full name is required"
+            }
+          },
+          "routingNumber": {
+            "label": "Routing No.",
+            "errorMessages": {
+              "pattern": "Routing number must be 9 digits long",
+              "required": "Routing number is required"
+            },
+            "unknownInstitution": {
+              "message": "Unknown Institution",
+              "tooltip": "The routing number was not recognized. Please verify the routing number is correct before you proceed. If the routing number is wrong, the payment may be returned."
+            }
+          },
+          "accountNumber": {
+            "label": "Account No.",
+            "errorMessages": {
+              "pattern": "Account number must contain only digits",
+              "required": "Account number is required"
+            }
+          },
+          "recipient": {
+            "label": "The recipient is",
+            "personTitle": "A person",
+            "businessTitle": "A business",
+            "notSureTitle": "I'm not sure"
+          },
+          "saveCounterparty": {
+            "label": "Save contact for future transactions"
+          }
+        }
+      },
+      "counterpartyAddedStage": {
+        "successMessage": {
+          "firstLine": "New recipient was",
+          "secondLine": "added successfully!"
+        }
+      },
+      "enterAmountStage": {
+        "title": "",
+        "nextButton": "Continue",
+        "backButton": "Back",
+        "input": {
+          "title": "Amount",
+          "balance": {
+            "validMessage": "Available Balance",
+            "errorMessage": "Exceeding the available balance of"
+          }
+        }
+      },
+      "reviewStage": {
+        "title": "Review payment",
+        "nextButton": "Complete payment",
+        "backButton": "Back",
+        "footnote": {
+          "regularText": "Funds will be available",
+          "boldText": "in 1-3 business days"
+        },
+        "descriptionList": {
+          "amount": "Amount",
+          "date": "Date",
+          "fee": "Fee"
+        },
+        "input": {
+          "label": "Description (optional)",
+          "note": "Visible to the recipient"
+        }
+      },
+      "completedStage": {
+        "messages": {
+          "pendingMessage": {
+            "title": "Payment created",
+            "subtitle": "Transfer expected by {{date}}"
+          },
+          "errorMessage": {
+            "title": "Something went wrong",
+            "subtitle": "Please try again later"
+          },
+          "rejectedMessages": {
+            "title": "The payment could not be sent",
+            "subtitle": {
+              "accountClosed": "The recipient's account has been closed",
+              "accountFrozen": "The recipient's account has been frozen",
+              "insufficientFunds": "The recipient's account has insufficient funds",
+              "dailyAchCreditLimitExceeded": "**** exceeds your daily / monthly limit"
+            }
+          }
+        }
+      },
+      "withPlaid": {
+        "flowTitle": "Make Payment",
+        "accountsListStage": {
+          "title": "Pull funds from"
+        },
+        "counterpartiesListStage": {
+          "title": "Push funds to",
+          "backButton": "Back",
+          "listTitle": "Select destination account",
+          "addButton": "New account",
+          "destination": "Destination account"
+        },
+        "emptyListStage": {
+          "title": "Send payment to",
+          "nextButton": "Add New Recipient",
+          "backButton": "Back",
+          "destination": "Destination account",
+          "message": {
+            "title": "You haven’t added any accounts",
+            "subtitle": "Easily add your first account and transfer money easily & quickly"
+          }
+        },
+        "counterpartyAddedStage": {
+          "successMessage": {
+            "firstLine": "New account was",
+            "secondLine": "connected successfully!"
+          }
+        },
+        "enterAmountStage": {
+          "title": "New transfer",
+          "nextButton": "Continue",
+          "backButton": "Back",
+          "input": {
+            "title": "Amount"
+          }
+        },
+        "reviewStage": {
+          "title": "Review transfer",
+          "nextButton": "Complete payment",
+          "backButton": "Back",
+          "footnote": {
+            "regularText": "Funds will be available",
+            "boldText": "in 1-3 business days"
+          },
+          "descriptionList": {
+            "amount": "Amount",
+            "date": "Transaction Date",
+            "fee": "Fee"
+          },
+          "input": {
+            "label": "Description (optional)",
+            "note": "Visible to the account"
+          }
+        },
+        "completedStage": {
+          "messages": {
+            "pendingMessage": {
+              "title": "Payment created",
+              "subtitle": "Transfer expected by {{date}}"
+            },
+            "errorMessage": {
+              "title": "Something went wrong",
+              "subtitle": "Please try again later"
+            },
+            "rejectedMessages": {
+              "title": "The transfer could not be sent",
+              "subtitle": {
+                "accountClosed": "The recipient's account has been closed",
+                "accountFrozen": "The recipient's account has been frozen",
+                "insufficientFunds": "The recipient's account has insufficient funds",
+                "dailyAchCreditLimitExceeded": "**** exceeds your daily / monthly limit"
+              }
+            }
+          }
+        }
+      }
+    },
+    "elementsBookPayment": {
+      "flowTitle": "",
+      "accountsListStage": {
+        "title": "Send payment from"
+      },
+      "counterpartiesListStage": {
+        "title": "Send payment to",
+        "listTitle": "Select destination account",
+        "backButton": "Back",
+        "destination": "Destination account"
+      },
+      "enterAmountStage": {
+        "title": "",
+        "nextButton": "Continue",
+        "backButton": "Back",
+        "input": {
+          "title": "Amount",
+          "balance": {
+            "validMessage": "Available Balance",
+            "errorMessage": "Exceeding the available balance of"
+          }
+        }
+      },
+      "reviewStage": {
+        "title": "Review transfer",
+        "nextButton": "Complete payment",
+        "backButton": "Back",
+        "footnote": {
+          "regularText": "Funds will be available",
+          "boldText": "immediately"
+        },
+        "descriptionList": {
+          "amount": "Amount",
+          "date": "Transaction Date"
+        },
+        "input": {
+          "label": "Description (optional)",
+          "note": "Visible to the recipient"
+        }
+      },
+      "completedStage": {
+        "messages": {
+          "sentMessage": {
+            "title": "You've sent ${{amount}} to {{counterparty}}",
+            "subtitle": ""
+          },
+          "errorMessage": {
+            "title": "Something went wrong!",
+            "subtitle": "Please try again later"
+          },
+          "rejectedMessages": {
+            "title": "The payment could not be sent",
+            "subtitle": {
+              "accountClosed": "The recipient's account has been closed",
+              "accountFrozen": "The recipient's account has been frozen",
+              "insufficientFunds": "The recipient's account has insufficient funds"
+            }
+          }
+        }
+      }
+    },
+    "elementsFundAccount": {
+      "flowTitle": "Fund my account",
+      "accountsListStage": {
+        "title": "Push funds to",
+        "backButton": "Back",
+        "destination": "Destination account"
+      },
+      "counterpartiesListStage": {
+        "title": "Pull funds from",
+        "addButton": "New card"
+      },
+      "emptyListStage": {
+        "title": "Pull funds from",
+        "nextButton": "Add New Card",
+        "message": {
+          "title": "Connect a Debit card",
+          "subtitle": "Instantly fund your account by connecting your card"
+        }
+      },
+      "counterpartyAddedStage": {
+        "successMessage": {
+          "firstLine": "New card was added",
+          "secondLine": "successfully!"
+        }
+      },
+      "enterAmountStage": {
+        "title": "Push funds to",
+        "nextButton": "Continue",
+        "backButton": "Back",
+        "input": {
+          "title": "Amount"
+        }
+      },
+      "reviewStage": {
+        "title": "Review payment",
+        "nextButton": "Complete payment",
+        "backButton": "Back",
+        "footnote": {
+          "regularText": "Funds will be available",
+          "boldText": "immediately"
+        },
+        "descriptionList": {
+          "amount": "Amount",
+          "fee": "fee",
+          "date": "Transaction Date"
+        },
+        "input": {
+          "label": "Description (optional)",
+          "note": "Visible to the recipient"
+        }
+      },
+      "completedStage": {
+        "messages": {
+          "pendingMessage": {
+            "title": "Account funded with ${{amount}}",
+            "subtitle": "Transfer expected by {{date}}"
+          },
+          "errorMessage": {
+            "title": "Something went wrong",
+            "subtitle": "Please try again later"
+          },
+          "rejectedMessages": {
+            "title": "The payment could not be sent",
+            "subtitle": {
+              "accountClosed": "The recipient's account has been closed",
+              "accountFrozen": "The recipient's account has been frozen",
+              "insufficientFunds": "The recipient's account has insufficient funds"
+            }
+          }
+        }
+      },
+      "addNewCounterpartyStage": {
+        "title": "Pull funds from",
+        "nextButton": "Complete payment",
+        "backButton": "Back",
+        "note": "The card will be saved for future payments",
+        "loaderInfo": "Loading...",
+        "form": {
+          "title": "Connect a new debit card",
+          "sensitiveFields": {
+            "firstName": {
+              "label": "First Name",
+              "errorMessages": {
+                "required": "Required"
+              }
+            },
+            "lastName": {
+              "label": "Last Name",
+              "errorMessages": {
+                "required": "Required"
+              }
+            },
+            "cardNumber": {
+              "label": "Card Number",
+              "errorMessages": {
+                "required": "Required",
+                "cardNumber": "is not a valid card number"
+              }
+            },
+            "expirationDate": {
+              "label": "Expiration Date",
+              "errorMessages": {
+                "required": "Required",
+                "expirationDate": "is not a valid expiration date"
+              }
+            },
+            "cvv2": {
+              "label": "CVV2",
+              "errorMessages": {
+                "required": "Required",
+                "securityCode": "is not a valid security code"
+              }
+            }
+          },
+          "nonSensitiveFields": {
+            "street": {
+              "label": "Street address",
+              "errorMessages": {
+                "required": "Please enter your street address"
+              }
+            },
+            "city": {
+              "label": "City",
+              "errorMessages": {
+                "required": "Please enter your city"
+              }
+            },
+            "state": {
+              "label": "State",
+              "errorMessages": {
+                "required": "Please select your state"
+              }
+            },
+            "postalCode": {
+              "label": "Zip code",
+              "errorMessages": {
+                "required": "Please enter your zip code",
+                "pattern": "Zip code must be 5 or 9 digits long"
+              }
+            }
+          }
+        }
+      }
+    },
+    "elementsCheckDeposit": {
+      "enterAmount": {
+        "actionTitle": "Check Deposit",
+        "actionSubtitle": "New Check",
+        "fromTitle": "Check Deposit",
+        "amountTitle": "Check amount",
+        "dailyLimitWarning": "Exceeding the daily limit of ",
+        "monthlyLimitWarning": "Exceeding the monthly limit of ",
+        "nextButton": "Continue"
+      },
+      "frontGuide": {
+        "title": "Mobile Check Deposit Guide",
+        "placement": "Place the check on a dark surface, in a well lit area",
+        "center": "Center the check within the photo borders",
+        "hold": "Hold still, we’ll capture the photo for you",
+        "backButton": "Back",
+        "nextButton": "I’m ready"
+      },
+      "backGuide": {
+        "description": "Your {{brandName}} bank account is managed by {{bankName}}",
+        "instruction": "Please make sure to sign the back and write",
+        "writeOnBack": "“For mobile deposit at {{bankName}}“",
+        "nextButton": "Got it"
+      },
+      "checkScan": {
+        "frontTitle": "Front",
+        "backTitle": "Back",
+        "messages": {
+          "firstMessage": "Make sure to place the check on a dark, flat surface",
+          "errorFourCorners": "Make sure all 4 corners of the check are inside the borders",
+          "errorTooClose": "Move the camera further away from your check",
+          "errorTooFar": "Move the camera closer to your check",
+          "errorNotCentered": "Center your document on a dark background",
+          "errorTooDark": "There is not enough light on your check",
+          "errorLowContrast": "Center your document on a dark background"
+        }
+      },
+      "checkImageReview": {
+        "frontTitle": "Front",
+        "backTitle": "Back",
+        "retake": "Retake",
+        "use": "Use"
+      },
+      "checkDepositReview": {
+        "actionTitle": "Check Deposit",
+        "actionSubtitle": "Review deposit",
+        "fromTitle": "Check Deposit",
+        "amount": "Amount",
+        "fee": "Fee",
+        "date": "Date",
+        "front": "Front",
+        "back": "Back",
+        "description": "Description (optional)",
+        "nextButton": "Authorize deposit",
+        "backButton": "Back"
+      },
+      "success": {
+        "actionTitle": "Check deposit submitted",
+        "actionSubtitle": "Deposit to {{accountPurpose}} account",
+        "processing": "Processing",
+        "confirmationNumber": "Confirmation #",
+        "infoMessage": "Make sure to keep your check for 14 days or until it clears",
+        "nextButton": "Deposit another check"
+      },
+      "failure": {
+        "actionTitle": "Something went wrong",
+        "actionSubtitle": "Please try again later",
+        "backButton": "Back"
+      }
+    },
+    "elementsActivity": {
+      "activityTable": {
+        "title": "Account Activity",
+        "tableSubTitle": {
+          "pending": "Pending",
+          "recentActivity": "Recent Activity"
+        },
+        "columns": {
+          "createdAt": "Date",
+          "summary": "Description",
+          "type": "Type",
+          "amount": "Amount",
+          "account": "Account"
+        },
+        "messages": {
+          "filterTooNarrow": "Your filter settings are too narrow, try again.",
+          "noActivity": "There was no activity in your account."
+        },
+        "backToTop": "Back to top"
+      },
+      "activityRecord": {
+        "paidBy": "Paid by",
+        "date": "Date",
+        "time": "Time",
+        "method": "Method",
+        "purchaseFrom": "Purchase from",
+        "address": "Address",
+        "type": "Type",
+        "status": "Status",
+        "name": "Name",
+        "routingNumber": "Routing Number",
+        "summary": "Summary",
+        "direction": "Direction",
+        "madeBy": "Made by",
+        "atmName": "ATM Name",
+        "atmLocation": "ATM Location",
+        "purpose": "Purpose",
+        "accountNumber": "Account Number"
+      },
+      "activityFilters": {
+        "title": "Filter",
+        "directionFilter": {
+          "title": "Direction",
+          "all": "All",
+          "received": "Received",
+          "sent": "Sent"
+        },
+        "typeFilter": {
+          "title": "Type",
+          "all": "All",
+          "checks": "Checks",
+          "bankTransfer": "Bank Transfer",
+          "cards": "Cards",
+          "atm": "ATM",
+          "interest": "Interest",
+          "fee": "Fee",
+          "reward": "Reward"
+        },
+        "dateFilter": {
+          "title": "Date",
+          "allTime": "All time",
+          "last7days": "last 7 days",
+          "last30days": "last 30 days",
+          "last3months": "last 3 months",
+          "last6months": "last 6 months",
+          "lastYear": "last year"
+        },
+        "actions": {
+          "clearAll": "Clear All",
+          "applyFilters": "Apply filters"
+        }
+      }
+    },
+    "elementsMultipleCards": {
+      "title": "Cards",
+      "emptyText": "No cards yet...",
+      "backToTop": "Back to Top",
+      "columns": {
+        "details": "CARD DETAILS",
+        "fullName": "CARD HOLDER",
+        "account": "ACCOUNT",
+        "type": "TYPE",
+        "expirationDate": "EXP. DATE",
+        "status": "STATUS"
+    }
+  }
+}

--- a/spec/fixtures/language_updated.json
+++ b/spec/fixtures/language_updated.json
@@ -1,0 +1,974 @@
+{
+    "name": "Unit-Ruby Specs Updated English Language Config",
+    "global": {
+      "days": {
+        "yesterday": "Yesterday",
+        "today": "Today"
+      },
+      "toasts": {
+        "copy": "Copied"
+      },
+      "months": {
+        "january": "Janyary",
+        "february": "Febby",
+        "march": "Myarsh",
+        "april": "Ahpreel",
+        "may": "Meje",
+        "june": "Joone",
+        "july": "Judy",
+        "august": "Aygist",
+        "september": "Septebber",
+        "october": "Octopus",
+        "november": "Novii",
+        "december": "Decembah"
+      },
+      "states": {
+        "AL": "Alabama",
+        "AK": "Alaska",
+        "AZ": "Arizona",
+        "AR": "Arkansas",
+        "CA": "California",
+        "CO": "Colorado",
+        "CT": "Connecticut",
+        "DE": "Delaware",
+        "DC": "District Of Columbia",
+        "FL": "Florida",
+        "GA": "Georgia",
+        "HI": "Hawaii",
+        "ID": "Idaho",
+        "IL": "Illinois",
+        "IN": "Indiana",
+        "IA": "Iowa",
+        "KS": "Kansas",
+        "KY": "Kentucky",
+        "LA": "Louisiana",
+        "ME": "Maine",
+        "MD": "Maryland",
+        "MA": "Massachusetts",
+        "MI": "Michigan",
+        "MN": "Minnesota",
+        "MS": "Mississippi",
+        "MO": "Missouri",
+        "MT": "Montana",
+        "NE": "Nebraska",
+        "NV": "Nevada",
+        "NH": "New Hampshire",
+        "NJ": "New Jersey",
+        "NM": "New Mexico",
+        "NY": "New York",
+        "NC": "North Carolina",
+        "ND": "North Dakota",
+        "OH": "Ohio",
+        "OK": "Oklahoma",
+        "OR": "Oregon",
+        "PA": "Pennsylvania",
+        "RI": "Rhode Island",
+        "SC": "South Carolina",
+        "SD": "South Dakota",
+        "TN": "Tennessee",
+        "TX": "Texas",
+        "UT": "Utah",
+        "VT": "Vermont",
+        "VA": "Virginia",
+        "WA": "Washington",
+        "WV": "West Virginia",
+        "WI": "Wisconsin",
+        "WY": "Wyoming"
+      },
+      "accountPurpose": {
+        "taxes": "taxes",
+        "saving": "saving",
+        "savings": "savings",
+        "generic": "generic",
+        "account": "account",
+        "checking": "checking",
+        "expenses": "expenses",
+        "spending": "spending"
+      }
+    },
+    "elementsCard": {
+      "title": {
+        "virtual": "Virtual Card {{cardNumberLast4Digits}}",
+        "physical": "Physical Card {{cardNumberLast4Digits}}"
+      },
+      "goodThru": "GOOD \n THRU",
+      "types": {
+        "debit": "Debit",
+        "credit": "Credit",
+        "individual": "Individual",
+        "business": "Business",
+        "virtual": "Virtual",
+        "physical": "Physical"
+      },
+      "statuses": {
+        "lost": "Lost",
+        "active": "Active",
+        "stolen": "Stolen",
+        "frozen": "Frozen",
+        "inactive": "Inactive",
+        "closedByCustomer": "Closed",
+        "suspectedFraud": "Disabled"
+      },
+      "sensitiveDataButton": {
+        "show": "Show Details",
+        "hide": "Hide Details"
+      },
+      "menuItems": {
+        "title": "Manage Card",
+        "freeze": "Freeze",
+        "close": "Close Card",
+        "unfreeze": "Unfreeze",
+        "managePin": "Manage PIN",
+        "replace": "Replace Card",
+        "lostOrStolen": "Report Lost or Stolen",
+        "addToWallet": "Manage {{walletName}} Wallet"
+      },
+      "actions": {
+        "common": {
+          "proceedButton": "Proceed",
+          "backButton": "Back",
+          "errorResponse": {
+            "title": "Something went wrong",
+            "description": "Please try again later"
+          }
+        },
+        "activate": {
+          "overlayButton": "Activate",
+          "form": {
+            "flowTitle": "Card Activation",
+            "mainTitle": "Activate your card",
+            "description": "Provide your card details below",
+            "expirationDate": {
+              "label": "Expiration Date",
+              "errorMessages": {
+                "required": "Required",
+                "expirationDate": "The expiration date is invalid"
+              }
+            },
+            "cvv2": {
+              "label": "CVV2",
+              "errorMessages": {
+                "required": "Required",
+                "securityCode": "The security code is invalid"
+              }
+            }
+          },
+          "response": {
+            "title": "The card has been activated",
+            "description": "Taking you to set up your Pin"
+          }
+        },
+        "freeze": {
+          "flowTitle": "Freeze card",
+          "mainTitle": "Are you sure you want to freeze this card?",
+          "description": "You won’t be able to use your card while it is frozen, but you can unfreeze it at any time."
+        },
+        "unfreeze": {
+          "flowTitle": "Unfreeze card",
+          "mainTitle": "Are you sure you want to unfreeze this card?"
+        },
+        "managePin": {
+          "flowTitle": "Manage PIN",
+          "setPin": {
+            "mainTitle": "Set your new card PIN",
+            "enterPin": {
+              "label": "Enter a four digit PIN code",
+              "errorMessages": {
+                "required": "Required",
+                "pattern": "Make sure the PIN includes digits only"
+              }
+            },
+            "reenterPin": {
+              "label": "Validate PIN",
+              "errorMessages": {
+                "required": "Required",
+                "pattern": "Make sure the PIN includes digits only",
+                "comparison": "Make sure to enter the same PIN number"
+              }
+            },
+            "response": {
+              "title": "Your card PIN is set",
+              "description": "Your card is ready for use"
+            }
+          },
+          "changePin": {
+            "mainTitle": "Change your PIN",
+            "currentPin": {
+              "label": "Your current PIN",
+              "errorMessages": {
+                "required": "Required",
+                "pattern": "Make sure the PIN includes digits only"
+              }
+            },
+            "newPin": {
+              "label": "New PIN code",
+              "errorMessages": {
+                "required": "Required",
+                "pattern": "Make sure the PIN includes digits only"
+              }
+            },
+            "newPinConfirm": {
+              "label": "Confirm new PIN",
+              "errorMessages": {
+                "required": "Required",
+                "pattern": "Make sure the PIN includes digits only",
+                "comparison": "Make sure to enter the same PIN number"
+              }
+            },
+            "response": {
+              "title": "Your card PIN is set"
+            }
+          }
+        },
+        "replace": {
+          "flowTitle": "Replace card",
+          "mainTitle": "Confirm shipping address",
+          "description": "Your card will be shipped to this address in 5-7 business days",
+          "formButton": "Change address",
+          "form": {
+            "title": "Update your shipping address",
+            "subtitle": "Your card will be shipped to this address in 5-7 business days",
+            "submitButton": "Confirm address",
+            "street": {
+              "label": "Street address",
+              "errorMessages": {
+                "required": "Please enter your street address"
+              }
+            },
+            "street2": {
+              "label": "Apt, Suite, Unit"
+            },
+            "city": {
+              "label": "City",
+              "errorMessages": {
+                "required": "Please enter your city"
+              }
+            },
+            "state": {
+              "label": "State",
+              "errorMessages": {
+                "required": "Please select your state"
+              }
+            },
+            "postalCode": {
+              "label": "Zip code",
+              "errorMessages": {
+                "required": "Please enter your zip code",
+                "pattern": "Zip code must be 5 or 9 digits long"
+              }
+            }
+          },
+          "response": {
+            "title": "Your replacement card is on the way",
+            "description": "Expect your card to arrive in 5-7 business days"
+          }
+        },
+        "report": {
+          "flowTitle": "Report card",
+          "mainTitle": "Report card ending with {{maskedCardNumberLast4Digits}}",
+          "description": "What happened to your card?",
+          "confirmationTitle": "Are you sure you want to report this card?",
+          "confirmationDescription": "Reporting your card will close it permanently.",
+          "radioButtons": {
+            "lost": "My card was lost",
+            "stolen": "My card was stolen"
+          },
+          "admonition": {
+            "description": "A Lost or Stolen card will be permanently closed.",
+            "link": "Learn more"
+          },
+          "response": {
+            "title": "Your card was closed",
+            "description": {
+              "lost": "Your card was reported Lost and you won't be able to make transactions using it",
+              "stolen": "Your card was reported Stolen and you won't be able to make transactions using it"
+            }
+          }
+        },
+        "close": {
+          "flowTitle": "Close card",
+          "mainTitle": "Are you sure you want to close card ending with {{maskedCardNumberLast4Digits}}?",
+          "description": "You won't be able to activate this card later",
+          "admonition": {
+            "description": "Closing this card is permanent and cannot be reversed.",
+            "link": "Learn more"
+          },
+          "response": {
+            "title": "Your card is closed",
+            "description": "It can no longer be used"
+          }
+        },
+        "addToWallet": {
+          "flowTitle": "Mobile wallet",
+          "mainTitle": "Add your card to {{walletName}} wallet",
+          "description": "Add your card for easy payment with the wallet app anywhere.",
+          "response": {
+            "title": "Your card was successfully added to {{walletName}} wallet"
+          }
+        }
+      }
+    },
+    "elementsAccount": {
+      "title": "{{accountPurposeWords}} {{maskedAccountNumber}}",
+      "availableBalance": "Available Balance",
+      "creditBalance": "Credit Balance",
+      "accountActions": {
+        "title": "Account Actions",
+        "accountDetails": "Account Details",
+        "accountStatements": "Account Statements",
+        "bankVerificationLetter": "Bank Verification Letter"
+      },
+      "accountDetails": {
+        "title": "Account {{maskedAccountNumber}}",
+        "subtitle": "{{accountName}}",
+        "accountOwner": "Account owner",
+        "accountNumber": "Account number",
+        "accountRoutingNumber": "Routing number",
+        "accountPurpose": "Account Purpose",
+        "bank": "Bank"
+      },
+      "accountStatements": {
+        "title": "Account Statements",
+        "subtitle": "Download account statement for account ending with #{{accountNumberLast4Digits}}",
+        "downloadStatementButton": "Save Statement",
+        "downloadStatementErrorMessage": "Download failed , try again later",
+        "emptyStatementsMessage": "There are no account statements available"
+      },
+      "accountList": {
+        "title": "Switch Account",
+        "accountTitle": "{{accountPurposeWords}} {{maskedAccountNumber}}",
+        "accountSubtitle": "{{accountName}}"
+      }
+    },
+    "elementsAchDebit": {
+      "flowTitle": "Fund my account",
+      "accountsListStage": {
+        "title": "Pull funds to",
+        "listTitle": "Select destination account",
+        "backButton": "Back",
+        "destination": "Destination account"
+      },
+      "counterpartiesListStage": {
+        "title": "Pull funds from",
+        "addButton": "New account"
+      },
+      "emptyListStage": {
+        "title": "Pull funds from",
+        "nextButton": "Connect New Account",
+        "message": {
+          "title": "Connect your first account",
+          "subtitle": "Log in instantly and securely to your accounts, no matter in which bank. This will allow you to transfer money and fund your account"
+        }
+      },
+      "counterpartyAddedStage": {
+        "successMessage": {
+          "firstLine": "New account was",
+          "secondLine": "connected successfully!"
+        }
+      },
+      "enterAmountStage": {
+        "title": "New transfer",
+        "nextButton": "Continue",
+        "backButton": "Back",
+        "input": {
+          "title": "Amount"
+        }
+      },
+      "reviewStage": {
+        "title": "Review transfer",
+        "nextButton": "Complete payment",
+        "backButton": "Back",
+        "footnote": {
+          "regularText": "Funds will be available",
+          "boldText": "in 1-3 business days"
+        },
+        "descriptionList": {
+          "amount": "Amount",
+          "fee": "Fee",
+          "date": "Transaction Date"
+        },
+        "input": {
+          "label": "Description (optional)",
+          "note": "Visible to the recipient"
+        }
+      },
+      "completedStage": {
+        "messages": {
+          "pendingMessage": {
+            "title": "Account funded with ${{amount}}",
+            "subtitle": "Transfer expected by {{date}}"
+          },
+          "errorMessage": {
+            "title": "Something went wrong",
+            "subtitle": "Please try again later"
+          },
+          "rejectedMessages": {
+            "title": "The transfer could not be sent",
+            "subtitle": {
+              "accountClosed": "The recipient's account has been closed",
+              "accountFrozen": "The recipient's account has been frozen",
+              "insufficientFunds": "The recipient's account has insufficient funds"
+            }
+          }
+        }
+      }
+    },
+    "elementsAchCredit": {
+      "flowTitle": "",
+      "accountsListStage": {
+        "title": "Send payment from"
+      },
+      "counterpartiesListStage": {
+        "title": "Send payment to",
+        "backButton": "Back",
+        "listTitle": "Select destination recipient",
+        "addButton": "New recipient",
+        "destination": "Destination recipient"
+      },
+      "emptyListStage": {
+        "title": "Send payment to",
+        "nextButton": "Add New Recipient",
+        "backButton": "Back",
+        "destination": "Destination recipient",
+        "message": {
+          "title": "You haven’t added any recipients",
+          "subtitle": "Easily add your first recipient and transfer money easily & quickly"
+        }
+      },
+      "addNewCounterpartyStage": {
+        "title": "New recipient",
+        "nextButton": "Continue",
+        "backButton": "Back",
+        "form": {
+          "fullName": {
+            "label": "Full Name",
+            "errorMessages": {
+              "minLength": "Full name must contain at least 2 letters",
+              "required": "Full name is required"
+            }
+          },
+          "routingNumber": {
+            "label": "Routing No.",
+            "errorMessages": {
+              "pattern": "Routing number must be 9 digits long",
+              "required": "Routing number is required"
+            },
+            "unknownInstitution": {
+              "message": "Unknown Institution",
+              "tooltip": "The routing number was not recognized. Please verify the routing number is correct before you proceed. If the routing number is wrong, the payment may be returned."
+            }
+          },
+          "accountNumber": {
+            "label": "Account No.",
+            "errorMessages": {
+              "pattern": "Account number must contain only digits",
+              "required": "Account number is required"
+            }
+          },
+          "recipient": {
+            "label": "The recipient is",
+            "personTitle": "A person",
+            "businessTitle": "A business",
+            "notSureTitle": "I'm not sure"
+          },
+          "saveCounterparty": {
+            "label": "Save contact for future transactions"
+          }
+        }
+      },
+      "counterpartyAddedStage": {
+        "successMessage": {
+          "firstLine": "New recipient was",
+          "secondLine": "added successfully!"
+        }
+      },
+      "enterAmountStage": {
+        "title": "",
+        "nextButton": "Continue",
+        "backButton": "Back",
+        "input": {
+          "title": "Amount",
+          "balance": {
+            "validMessage": "Available Balance",
+            "errorMessage": "Exceeding the available balance of"
+          }
+        }
+      },
+      "reviewStage": {
+        "title": "Review payment",
+        "nextButton": "Complete payment",
+        "backButton": "Back",
+        "footnote": {
+          "regularText": "Funds will be available",
+          "boldText": "in 1-3 business days"
+        },
+        "descriptionList": {
+          "amount": "Amount",
+          "date": "Date",
+          "fee": "Fee"
+        },
+        "input": {
+          "label": "Description (optional)",
+          "note": "Visible to the recipient"
+        }
+      },
+      "completedStage": {
+        "messages": {
+          "pendingMessage": {
+            "title": "Payment created",
+            "subtitle": "Transfer expected by {{date}}"
+          },
+          "errorMessage": {
+            "title": "Something went wrong",
+            "subtitle": "Please try again later"
+          },
+          "rejectedMessages": {
+            "title": "The payment could not be sent",
+            "subtitle": {
+              "accountClosed": "The recipient's account has been closed",
+              "accountFrozen": "The recipient's account has been frozen",
+              "insufficientFunds": "The recipient's account has insufficient funds",
+              "dailyAchCreditLimitExceeded": "**** exceeds your daily / monthly limit"
+            }
+          }
+        }
+      },
+      "withPlaid": {
+        "flowTitle": "Make Payment",
+        "accountsListStage": {
+          "title": "Pull funds from"
+        },
+        "counterpartiesListStage": {
+          "title": "Push funds to",
+          "backButton": "Back",
+          "listTitle": "Select destination account",
+          "addButton": "New account",
+          "destination": "Destination account"
+        },
+        "emptyListStage": {
+          "title": "Send payment to",
+          "nextButton": "Add New Recipient",
+          "backButton": "Back",
+          "destination": "Destination account",
+          "message": {
+            "title": "You haven’t added any accounts",
+            "subtitle": "Easily add your first account and transfer money easily & quickly"
+          }
+        },
+        "counterpartyAddedStage": {
+          "successMessage": {
+            "firstLine": "New account was",
+            "secondLine": "connected successfully!"
+          }
+        },
+        "enterAmountStage": {
+          "title": "New transfer",
+          "nextButton": "Continue",
+          "backButton": "Back",
+          "input": {
+            "title": "Amount"
+          }
+        },
+        "reviewStage": {
+          "title": "Review transfer",
+          "nextButton": "Complete payment",
+          "backButton": "Back",
+          "footnote": {
+            "regularText": "Funds will be available",
+            "boldText": "in 1-3 business days"
+          },
+          "descriptionList": {
+            "amount": "Amount",
+            "date": "Transaction Date",
+            "fee": "Fee"
+          },
+          "input": {
+            "label": "Description (optional)",
+            "note": "Visible to the account"
+          }
+        },
+        "completedStage": {
+          "messages": {
+            "pendingMessage": {
+              "title": "Payment created",
+              "subtitle": "Transfer expected by {{date}}"
+            },
+            "errorMessage": {
+              "title": "Something went wrong",
+              "subtitle": "Please try again later"
+            },
+            "rejectedMessages": {
+              "title": "The transfer could not be sent",
+              "subtitle": {
+                "accountClosed": "The recipient's account has been closed",
+                "accountFrozen": "The recipient's account has been frozen",
+                "insufficientFunds": "The recipient's account has insufficient funds",
+                "dailyAchCreditLimitExceeded": "**** exceeds your daily / monthly limit"
+              }
+            }
+          }
+        }
+      }
+    },
+    "elementsBookPayment": {
+      "flowTitle": "",
+      "accountsListStage": {
+        "title": "Send payment from"
+      },
+      "counterpartiesListStage": {
+        "title": "Send payment to",
+        "listTitle": "Select destination account",
+        "backButton": "Back",
+        "destination": "Destination account"
+      },
+      "enterAmountStage": {
+        "title": "",
+        "nextButton": "Continue",
+        "backButton": "Back",
+        "input": {
+          "title": "Amount",
+          "balance": {
+            "validMessage": "Available Balance",
+            "errorMessage": "Exceeding the available balance of"
+          }
+        }
+      },
+      "reviewStage": {
+        "title": "Review transfer",
+        "nextButton": "Complete payment",
+        "backButton": "Back",
+        "footnote": {
+          "regularText": "Funds will be available",
+          "boldText": "immediately"
+        },
+        "descriptionList": {
+          "amount": "Amount",
+          "date": "Transaction Date"
+        },
+        "input": {
+          "label": "Description (optional)",
+          "note": "Visible to the recipient"
+        }
+      },
+      "completedStage": {
+        "messages": {
+          "sentMessage": {
+            "title": "You've sent ${{amount}} to {{counterparty}}",
+            "subtitle": ""
+          },
+          "errorMessage": {
+            "title": "Something went wrong!",
+            "subtitle": "Please try again later"
+          },
+          "rejectedMessages": {
+            "title": "The payment could not be sent",
+            "subtitle": {
+              "accountClosed": "The recipient's account has been closed",
+              "accountFrozen": "The recipient's account has been frozen",
+              "insufficientFunds": "The recipient's account has insufficient funds"
+            }
+          }
+        }
+      }
+    },
+    "elementsFundAccount": {
+      "flowTitle": "Fund my account",
+      "accountsListStage": {
+        "title": "Push funds to",
+        "backButton": "Back",
+        "destination": "Destination account"
+      },
+      "counterpartiesListStage": {
+        "title": "Pull funds from",
+        "addButton": "New card"
+      },
+      "emptyListStage": {
+        "title": "Pull funds from",
+        "nextButton": "Add New Card",
+        "message": {
+          "title": "Connect a Debit card",
+          "subtitle": "Instantly fund your account by connecting your card"
+        }
+      },
+      "counterpartyAddedStage": {
+        "successMessage": {
+          "firstLine": "New card was added",
+          "secondLine": "successfully!"
+        }
+      },
+      "enterAmountStage": {
+        "title": "Push funds to",
+        "nextButton": "Continue",
+        "backButton": "Back",
+        "input": {
+          "title": "Amount"
+        }
+      },
+      "reviewStage": {
+        "title": "Review payment",
+        "nextButton": "Complete payment",
+        "backButton": "Back",
+        "footnote": {
+          "regularText": "Funds will be available",
+          "boldText": "immediately"
+        },
+        "descriptionList": {
+          "amount": "Amount",
+          "fee": "fee",
+          "date": "Transaction Date"
+        },
+        "input": {
+          "label": "Description (optional)",
+          "note": "Visible to the recipient"
+        }
+      },
+      "completedStage": {
+        "messages": {
+          "pendingMessage": {
+            "title": "Account funded with ${{amount}}",
+            "subtitle": "Transfer expected by {{date}}"
+          },
+          "errorMessage": {
+            "title": "Something went wrong",
+            "subtitle": "Please try again later"
+          },
+          "rejectedMessages": {
+            "title": "The payment could not be sent",
+            "subtitle": {
+              "accountClosed": "The recipient's account has been closed",
+              "accountFrozen": "The recipient's account has been frozen",
+              "insufficientFunds": "The recipient's account has insufficient funds"
+            }
+          }
+        }
+      },
+      "addNewCounterpartyStage": {
+        "title": "Pull funds from",
+        "nextButton": "Complete payment",
+        "backButton": "Back",
+        "note": "The card will be saved for future payments",
+        "loaderInfo": "Loading...",
+        "form": {
+          "title": "Connect a new debit card",
+          "sensitiveFields": {
+            "firstName": {
+              "label": "First Name",
+              "errorMessages": {
+                "required": "Required"
+              }
+            },
+            "lastName": {
+              "label": "Last Name",
+              "errorMessages": {
+                "required": "Required"
+              }
+            },
+            "cardNumber": {
+              "label": "Card Number",
+              "errorMessages": {
+                "required": "Required",
+                "cardNumber": "is not a valid card number"
+              }
+            },
+            "expirationDate": {
+              "label": "Expiration Date",
+              "errorMessages": {
+                "required": "Required",
+                "expirationDate": "is not a valid expiration date"
+              }
+            },
+            "cvv2": {
+              "label": "CVV2",
+              "errorMessages": {
+                "required": "Required",
+                "securityCode": "is not a valid security code"
+              }
+            }
+          },
+          "nonSensitiveFields": {
+            "street": {
+              "label": "Street address",
+              "errorMessages": {
+                "required": "Please enter your street address"
+              }
+            },
+            "city": {
+              "label": "City",
+              "errorMessages": {
+                "required": "Please enter your city"
+              }
+            },
+            "state": {
+              "label": "State",
+              "errorMessages": {
+                "required": "Please select your state"
+              }
+            },
+            "postalCode": {
+              "label": "Zip code",
+              "errorMessages": {
+                "required": "Please enter your zip code",
+                "pattern": "Zip code must be 5 or 9 digits long"
+              }
+            }
+          }
+        }
+      }
+    },
+    "elementsCheckDeposit": {
+      "enterAmount": {
+        "actionTitle": "Check Deposit",
+        "actionSubtitle": "New Check",
+        "fromTitle": "Check Deposit",
+        "amountTitle": "Check amount",
+        "dailyLimitWarning": "Exceeding the daily limit of ",
+        "monthlyLimitWarning": "Exceeding the monthly limit of ",
+        "nextButton": "Continue"
+      },
+      "frontGuide": {
+        "title": "Mobile Check Deposit Guide",
+        "placement": "Place the check on a dark surface, in a well lit area",
+        "center": "Center the check within the photo borders",
+        "hold": "Hold still, we’ll capture the photo for you",
+        "backButton": "Back",
+        "nextButton": "I’m ready"
+      },
+      "backGuide": {
+        "description": "Your {{brandName}} bank account is managed by {{bankName}}",
+        "instruction": "Please make sure to sign the back and write",
+        "writeOnBack": "“For mobile deposit at {{bankName}}“",
+        "nextButton": "Got it"
+      },
+      "checkScan": {
+        "frontTitle": "Front",
+        "backTitle": "Back",
+        "messages": {
+          "firstMessage": "Make sure to place the check on a dark, flat surface",
+          "errorFourCorners": "Make sure all 4 corners of the check are inside the borders",
+          "errorTooClose": "Move the camera further away from your check",
+          "errorTooFar": "Move the camera closer to your check",
+          "errorNotCentered": "Center your document on a dark background",
+          "errorTooDark": "There is not enough light on your check",
+          "errorLowContrast": "Center your document on a dark background"
+        }
+      },
+      "checkImageReview": {
+        "frontTitle": "Front",
+        "backTitle": "Back",
+        "retake": "Retake",
+        "use": "Use"
+      },
+      "checkDepositReview": {
+        "actionTitle": "Check Deposit",
+        "actionSubtitle": "Review deposit",
+        "fromTitle": "Check Deposit",
+        "amount": "Amount",
+        "fee": "Fee",
+        "date": "Date",
+        "front": "Front",
+        "back": "Back",
+        "description": "Description (optional)",
+        "nextButton": "Authorize deposit",
+        "backButton": "Back"
+      },
+      "success": {
+        "actionTitle": "Check deposit submitted",
+        "actionSubtitle": "Deposit to {{accountPurpose}} account",
+        "processing": "Processing",
+        "confirmationNumber": "Confirmation #",
+        "infoMessage": "Make sure to keep your check for 14 days or until it clears",
+        "nextButton": "Deposit another check"
+      },
+      "failure": {
+        "actionTitle": "Something went wrong",
+        "actionSubtitle": "Please try again later",
+        "backButton": "Back"
+      }
+    },
+    "elementsActivity": {
+      "activityTable": {
+        "title": "Account Activity",
+        "tableSubTitle": {
+          "pending": "Pending",
+          "recentActivity": "Recent Activity"
+        },
+        "columns": {
+          "createdAt": "Date",
+          "summary": "Description",
+          "type": "Type",
+          "amount": "Amount",
+          "account": "Account"
+        },
+        "messages": {
+          "filterTooNarrow": "Your filter settings are too narrow, try again.",
+          "noActivity": "There was no activity in your account."
+        },
+        "backToTop": "Back to top"
+      },
+      "activityRecord": {
+        "paidBy": "Paid by",
+        "date": "Date",
+        "time": "Time",
+        "method": "Method",
+        "purchaseFrom": "Purchase from",
+        "address": "Address",
+        "type": "Type",
+        "status": "Status",
+        "name": "Name",
+        "routingNumber": "Routing Number",
+        "summary": "Summary",
+        "direction": "Direction",
+        "madeBy": "Made by",
+        "atmName": "ATM Name",
+        "atmLocation": "ATM Location",
+        "purpose": "Purpose",
+        "accountNumber": "Account Number"
+      },
+      "activityFilters": {
+        "title": "Filter",
+        "directionFilter": {
+          "title": "Direction",
+          "all": "All",
+          "received": "Received",
+          "sent": "Sent"
+        },
+        "typeFilter": {
+          "title": "Type",
+          "all": "All",
+          "checks": "Checks",
+          "bankTransfer": "Bank Transfer",
+          "cards": "Cards",
+          "atm": "ATM",
+          "interest": "Interest",
+          "fee": "Fee",
+          "reward": "Reward"
+        },
+        "dateFilter": {
+          "title": "Date",
+          "allTime": "All time",
+          "last7days": "last 7 days",
+          "last30days": "last 30 days",
+          "last3months": "last 3 months",
+          "last6months": "last 6 months",
+          "lastYear": "last year"
+        },
+        "actions": {
+          "clearAll": "Clear All",
+          "applyFilters": "Apply filters"
+        }
+      }
+    },
+    "elementsMultipleCards": {
+      "title": "Cards",
+      "emptyText": "No cards yet...",
+      "backToTop": "Back to Top",
+      "columns": {
+        "details": "CARD DETAILS",
+        "fullName": "CARD HOLDER",
+        "account": "ACCOUNT",
+        "type": "TYPE",
+        "expirationDate": "EXP. DATE",
+        "status": "STATUS"
+    }
+  }
+}

--- a/spec/fixtures/theme_initial.json
+++ b/spec/fixtures/theme_initial.json
@@ -1,0 +1,96 @@
+{
+    "name": "Unit-Ruby Specs Default Theme",
+    "global": {
+        "avatar": {
+            "iconColor": "var(--primary-main)",
+            "borderColor": "var(--secondary-lighten-2)",
+            "backgroundColor": "var(--secondary-lighten-5)"
+        },
+        "logoUrl": "https://app.s.unit.sh/logo-dark.f1c96208.svg",
+        "colors": {
+            "success": "#93CCBC",
+            "background": "#FFFFFF",
+            "warning": "#F6D469",
+            "secondary": "#93CCBC",
+            "info": "#93CCBC",
+            "error": "#F95C5C",
+            "neutral": "#DADAE2",
+            "primary": "#26313B"
+        },
+        "buttons": {
+            "primary": {
+                "default": {
+                    "backgroundColor": "var(--primary-lighten-1)",
+                    "textColor": "var(--neutral-white)"
+                },
+                "hover": {
+                    "backgroundColor": "var(--primary-lighten-1)",
+                    "textColor": "var(--neutral-white)"
+                },
+                "active": {
+                    "backgroundColor": "var(--primary-lighten-1)"
+                }
+            }
+        },
+        "typography": {
+            "titles": {
+                "h3": {
+                    "color": "var(--primary-darken-4)"
+                },
+                "componentTitle": {
+                    "color": "var(--primary-darken-4)"
+                },
+                "emptyState": {
+                    "title": {
+                        "color": "var(--primary-darken-4)"
+                    }
+                },
+                "h2": {
+                    "color": "var(--primary-darken-4)"
+                },
+                "response": {
+                    "title": {
+                        "color": "var(--primary-darken-4)"
+                    }
+                },
+                "menuTitle": {
+                    "color": "var(--primary-darken-4)"
+                },
+                "flow": {
+                    "title": {
+                        "color": "var(--primary-darken-4)"
+                    }
+                },
+                "bigNumber": {
+                    "color": "var(--primary-lighten-4)"
+                },
+                "table": {
+                    "headers": {
+                        "color": "var(--primary-darken-4)"
+                    }
+                }
+            }
+        }
+    },
+    "elementsAccount": {
+        "titleColor": "var(--primary-darken-4)",
+        "balanceTitleColor": "var(--primary-darken-4)",
+        "coverBackgroundColor": "#F5F1EC"
+    },
+    "elementsCard": {
+        "designs": [
+            {
+                "name": "default",
+                "url": "https://d1xlopvhx2cz8k.cloudfront.net/resources/outlay.png",
+                "fontColor": "#fafafa",
+                "boxShadow": "0px 1px 20px 2px rgb(0 0 0 / 0.24)"
+            },
+            {
+                "name": "default_credit",
+                "url": "https://d1xlopvhx2cz8k.cloudfront.net/resources/outlaycredit2.png",
+                "fontColor": "#fafafa",
+                "boxShadow": "0px 1px 20px 2px rgb(0 0 0 / 0.24)"
+            }
+        ]
+    }
+}

--- a/spec/fixtures/theme_updated.json
+++ b/spec/fixtures/theme_updated.json
@@ -1,0 +1,96 @@
+{
+    "name": "Unit-Ruby Specs Updated Theme",
+    "global": {
+        "avatar": {
+            "iconColor": "var(--primary-main)",
+            "borderColor": "var(--secondary-lighten-2)",
+            "backgroundColor": "var(--secondary-lighten-5)"
+        },
+        "logoUrl": "https://some-other-logo.svg",
+        "colors": {
+            "success": "#93CCBC",
+            "background": "#FFFFFF",
+            "warning": "#F6D469",
+            "secondary": "#93CCBC",
+            "info": "#93CCBC",
+            "error": "#F95C5C",
+            "neutral": "#DADAE2",
+            "primary": "#26313B"
+        },
+        "buttons": {
+            "primary": {
+                "default": {
+                    "backgroundColor": "var(--primary-lighten-1)",
+                    "textColor": "var(--neutral-white)"
+                },
+                "hover": {
+                    "backgroundColor": "var(--primary-lighten-1)",
+                    "textColor": "var(--neutral-white)"
+                },
+                "active": {
+                    "backgroundColor": "var(--primary-lighten-1)"
+                }
+            }
+        },
+        "typography": {
+            "titles": {
+                "h3": {
+                    "color": "var(--primary-darken-4)"
+                },
+                "componentTitle": {
+                    "color": "var(--primary-darken-4)"
+                },
+                "emptyState": {
+                    "title": {
+                        "color": "var(--primary-darken-4)"
+                    }
+                },
+                "h2": {
+                    "color": "var(--primary-darken-4)"
+                },
+                "response": {
+                    "title": {
+                        "color": "var(--primary-darken-4)"
+                    }
+                },
+                "menuTitle": {
+                    "color": "var(--primary-darken-4)"
+                },
+                "flow": {
+                    "title": {
+                        "color": "var(--primary-darken-4)"
+                    }
+                },
+                "bigNumber": {
+                    "color": "var(--primary-lighten-4)"
+                },
+                "table": {
+                    "headers": {
+                        "color": "var(--primary-darken-4)"
+                    }
+                }
+            }
+        }
+    },
+    "elementsAccount": {
+        "titleColor": "var(--primary-darken-4)",
+        "balanceTitleColor": "var(--primary-darken-4)",
+        "coverBackgroundColor": "#F5F1EC"
+    },
+    "elementsCard": {
+        "designs": [
+            {
+                "name": "default",
+                "url": "https://d1xlopvhx2cz8k.cloudfront.net/resources/outlay.png",
+                "fontColor": "#fafafa",
+                "boxShadow": "0px 1px 20px 2px rgb(0 0 0 / 0.24)"
+            },
+            {
+                "name": "default_credit",
+                "url": "https://d1xlopvhx2cz8k.cloudfront.net/resources/outlaycredit2.png",
+                "fontColor": "#fafafa",
+                "boxShadow": "0px 1px 20px 2px rgb(0 0 0 / 0.24)"
+            }
+        ]
+    }
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'bundler/setup'
 require 'dotenv/load'
 require 'pry'
 require 'unit-ruby'
+require 'rspec/file_fixtures'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -17,8 +18,8 @@ end
 
 def establish_connection_to_api!
   Unit.configure do |config|
-    config.api_key = ENV['UNIT_API_KEY']
-    config.base_url = ENV['UNIT_BASE_URL']
+    config.api_key = ENV.fetch('UNIT_API_KEY', nil)
+    config.base_url = ENV.fetch('UNIT_BASE_URL', nil)
   end
 end
 

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Unit do
   it 'returns the correct version' do
-    expect(Unit::VERSION).to eq '0.9.0'
+    expect(Unit::VERSION).to eq '0.9.1'
   end
 end
+

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Unit do
   it 'returns the correct version' do
-    expect(Unit::VERSION).to eq '0.9.1'
+    expect(Unit::VERSION).to eq '0.10.0'
   end
 end
 

--- a/unit-ruby.gemspec
+++ b/unit-ruby.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rspec-file_fixtures', '~> 0.1.9'
   spec.add_development_dependency 'rubocop', '~> 1.24.1'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
Unit's white label components are configured via two big 'ole blobs of JSON. We create templates with said blob 'o JSON and then reference it whenever we render components. Right now, we don't have a source of truth for these config files which makes updating them awkward and error prone.

This PR adds fetching capabilities to the WhiteLabelTheme resource, and adds a matching WhiteLabelLanguage resource. This API call is a PUT, when the existing resource update API actions are PATCHes, so I'm adding a Replace resource action that exposes a #replace method (for taking in normal attribute hashes) and a #replace_json method (for taking a JSON blob like what we use for the theme and language configs).

In order for tests to run successfully, you'll need to set UNIT_THEME_ID and UNIT_LANGUAGE_ID env vars. I opted to have tests update existing resources instead of create new resources like the other specs do because I thought it'd be pretty annoying to have thousands of templates (there's no delete for these resources in the API).