### PR TITLE
Migrate to ApplicationForm v2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    unit-ruby (0.10.1)
+    unit-ruby (0.11.0)
       activesupport
       faraday (>= 2.0.1, < 3)
       faraday-retry

--- a/lib/unit-ruby/application_form.rb
+++ b/lib/unit-ruby/application_form.rb
@@ -1,18 +1,22 @@
 module Unit
   class ApplicationForm < APIResource
     path '/application-forms'
+    header 'X-Accept-Version' => 'V2024_06'
 
     attribute :tags, Types::Hash # Optional
     attribute :allowed_application_types, Types::Array # Optional. Array of Individual, Business or SoleProprietorship.
     attribute :applicant_details, Types::ApplicationFormPrefill # Optional. Add data that is already known about the end-customer to be auto populated on the form.
     attribute :settings_override, Types::ApplicationFormSettingsOverride # Optional. Override disclosure URLs that were defined in the application form settings.
-
-    attribute :stage, Types::String, readonly: true
-    attribute :url, Types::String, readonly: true
+    attribute :idempotency_key, Types::String
 
     belongs_to :application, class_name: 'Unit::IndividualApplication'
 
+    def url
+      links[:related][:href]
+    end
+
     include ResourceOperations::Create
     include ResourceOperations::Find
+    include ResourceOperations::List
   end
 end

--- a/lib/unit-ruby/util/api_resource.rb
+++ b/lib/unit-ruby/util/api_resource.rb
@@ -1,6 +1,6 @@
 module Unit
   class APIResource
-    attr_accessor :id, :type, :raw_data
+    attr_accessor :id, :type, :raw_data, :links
 
     def initialize(attributes = {})
       clear_attributes!
@@ -14,7 +14,7 @@ module Unit
     # Creates a base http connection to the API
     #
     def self.connection
-      @connection ||= Connection.new
+      @connection ||= Connection.new(headers)
     end
 
     # Defines the schema for a resource's attributes
@@ -64,6 +64,21 @@ module Unit
       return @path if route.nil?
 
       @path = route
+    end
+
+    # Sets resource-specific headers
+    #
+    # Usage:
+    #  class Customer < Unit::Resource
+    #      header 'X-Some-Header' => 'Header Value'
+    #  end
+    def self.header(header_key_value_pair)
+      key, value = header_key_value_pair.first
+      headers[key] = value
+    end
+
+    def self.headers
+      @headers ||= {}
     end
 
     def self.resource_path(id)
@@ -149,6 +164,7 @@ module Unit
       self.type = data[:type]
       self.raw_data = data
       self.relationships = data[:relationships]
+      self.links = data[:links]
 
       clear_attributes!
 

--- a/lib/unit-ruby/util/connection.rb
+++ b/lib/unit-ruby/util/connection.rb
@@ -10,11 +10,12 @@ module Unit
 
     attr_reader :connection
 
-    def initialize
+    def initialize(custom_headers = {})
       @connection = Faraday.new(self.class.base_url) do |f|
         f.headers['UNIT_TRUST_TOKEN'] = self.class.trust_token if self.class.trust_token
         f.headers['Authorization'] = "Bearer #{self.class.api_key}"
         f.headers['Content-Type'] = 'application/vnd.api+json'
+        f.headers.merge!(custom_headers)
         f.request :json # encode req bodies as JSON
         f.request :retry # retry transient failures
         f.response :json # decode response bodies as JSON

--- a/lib/unit-ruby/version.rb
+++ b/lib/unit-ruby/version.rb
@@ -1,3 +1,3 @@
 module Unit
-  VERSION = '0.10.1'
+  VERSION = '0.11.0'
 end

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Unit do
   it 'returns the correct version' do
-    expect(Unit::VERSION).to eq '0.10.1'
+    expect(Unit::VERSION).to eq '0.11.0'
   end
 end
 


### PR DESCRIPTION
Unit is deprecating the V1 of their ApplicationForm. This version has a few breaking changes:

- The new version is created and fetched by including a header in the requests. Fetching V1 ApplicationForms with this header will not be found, so this requires previous forms to be migrated to the new V2.
- The ApplicationForm response also doesn't include a "status" attribute anymore, so it's been removed from the resource.
- The ApplicationForm's create requires an idempotency key, so it's been added to the resource.