### PR TITLE
Add bank name to counterparty type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    unit-ruby (0.12.0)
+    unit-ruby (0.12.1)
       activesupport
       faraday (>= 2.0.1, < 3)
       faraday-retry

--- a/lib/unit-ruby/ach_counterparty.rb
+++ b/lib/unit-ruby/ach_counterparty.rb
@@ -6,6 +6,7 @@ module Unit
     attribute :tags, Types::Hash # Optional
 
     attribute :name, Types::String # Name of the account holder
+    attribute :bank, Types::String # Bank name
     attribute :created_at, Types::DateTime
     attribute :routing_number, Types::String # Routing number of account.
     attribute :account_number, Types::String # Account number, together with the routingNumber forms the identifier of the account on the ACH network.

--- a/lib/unit-ruby/version.rb
+++ b/lib/unit-ruby/version.rb
@@ -1,3 +1,3 @@
 module Unit
-  VERSION = '0.12.0'
+  VERSION = '0.12.1'
 end

--- a/spec/features/ach_counterparty_spec.rb
+++ b/spec/features/ach_counterparty_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Unit::AchCounterparty do
     counterparty = Unit::AchCounterparty.create(
       idempotency_key: SecureRandom.uuid,
       name: 'Jane Doe',
-      routing_number: '812345678',
+      routing_number: '021000021',
       account_number: '12345569',
       account_type: 'Checking',
       type: 'Person',
@@ -23,7 +23,8 @@ RSpec.describe Unit::AchCounterparty do
     )
 
     expect(counterparty.name).to eq 'Jane Doe'
-    expect(counterparty.routing_number).to eq '812345678'
+    expect(counterparty.bank).to eq 'Jpmorgan Chase Bank'
+    expect(counterparty.routing_number).to eq '021000021'
     expect(counterparty.account_number).to eq '12345569'
     expect(counterparty.account_type).to eq 'Checking'
     expect(counterparty.type).to eq 'Person'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,7 +65,7 @@ module Factory
 
     Unit::AchCounterparty.create(
       name: 'Test Counterparty',
-      routing_number: '876543210',
+      routing_number: '021000021',
       account_number: '123456789',
       account_type: 'Checking',
       type: 'Person',

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Unit do
   it 'returns the correct version' do
-    expect(Unit::VERSION).to eq '0.12.0'
+    expect(Unit::VERSION).to eq '0.12.1'
   end
 end
 


### PR DESCRIPTION
We want to be able to show a list of counterparties when users create recurring ACH payments. Routing numbers are readable for banking computers and not humans. We should show the associated bank name instead.