### PR TITLE
Release version 1.0.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 UNIT_API_KEY=v2.public.enter_your_api_key_here
 UNIT_BASE_URL=https://api.s.unit.sh
+UNIT_LANGUAGE_ID=123
+UNIT_THEME_ID=456

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["3.0", "3.3"]
+        ruby-version: ["3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v2

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -14,21 +14,21 @@ orientation.
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
   address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Our Responsibilities
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at chloe.isacke@gmail.com. All
+reported by contacting the project team at cto@retirable.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.6.0)
-    uri (1.0.2)
+    uri (1.0.3)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    unit-ruby (0.12.2)
+    unit-ruby (1.0.0)
       activesupport
       faraday (>= 2.0.1, < 3)
       faraday-retry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,9 @@ PATH
   remote: .
   specs:
     unit-ruby (1.0.0)
-      activesupport
-      faraday (>= 2.0.1, < 3)
-      faraday-retry
+      activesupport (~> 7)
+      faraday (~> 2)
+      faraday-retry (~> 2)
 
 GEM
   remote: https://rubygems.org/
@@ -83,12 +83,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  dotenv (~> 2.7.6)
-  pry
-  rake (~> 13.0)
-  rspec (~> 3.0)
+  dotenv (~> 2)
+  pry (~> 0.15)
+  rake (~> 13)
+  rspec (~> 3)
   rspec-file_fixtures (~> 0.1.9)
-  rubocop (~> 1.24.1)
+  rubocop (~> 1)
   unit-ruby!
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -1,8 +1,28 @@
-# Documentation
+# Unit Ruby
 
-The documentation for the Unit API can be found [here](https://docs.unit.co/).
+![Gem Version](https://img.shields.io/gem/v/unit-ruby)
+[![Ruby](https://github.com/retirable/unit-ruby/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/retirable/unit-ruby/actions/workflows/ci.yml)
+![GitHub License](https://img.shields.io/github/license/retirable/unit-ruby)
+
+A Ruby SDK for the [Unit's Banking-as-a-Service API](https://docs.unit.co/).
+
+> [!IMPORTANT]
+>
+> The development of the `unit-ruby` gem is sponsored and used in production by [Retirable](https://retirable).
+>
+> If you are starting a new project, you might want to consider Unit's officially supported gem, [`unit-ruby-sdk`](https://github.com/unit-finance/unit-ruby-sdk)
+
+## Features
+
+- Ruby SDK for Unit's Banking-as-a-Service API
+- Support for all major Unit API endpoints
+- Built-in error handling and response parsing
+- Production-ready and battle-tested by Retirable
+- Ruby 3.3+ compatibility
 
 ## Installation
+
+> **Requirements:** Ruby 3.3+
 
 Add this line to your application's Gemfile:
 
@@ -12,32 +32,100 @@ gem 'unit-ruby'
 
 And then execute:
 
-    $ bundle
+```bash
+$ bundle install
+```
 
 Or install it yourself as:
 
-    $ gem install unit-ruby
+```bash
+$ gem install unit-ruby
+```
 
-## Usage
+## Configuration
 
-To get started, add an initializer file for the `unit-ruby` gem e.g. in `config/initializers/unit.rb`.
+Configure the library with your credentials from Unit, (e.g., in `config/initializers/unit.rb` if you are using Ruby on Rails):
 
-```Ruby
+```ruby
 require 'unit-ruby'
 
 Unit.configure do |config|
-    config.api_key = ENV['UNIT_API_KEY']
-    config.base_url = ENV['UNIT_BASE_URL']
-    config.trust_token = ENV['UNIT_TRUST_TOKEN] # optional
+  config.api_key = ENV['UNIT_API_KEY'] # Your Unit API key (required)
+  config.base_url = ENV['UNIT_BASE_URL'] # Unit API base URL (required)
+  config.trust_token = ENV['UNIT_TRUST_TOKEN'] # Trust token for enhanced security (optional, requires additional configuration from Unit's support team)
 end
-
 ```
+
+## Usage
+
+```Ruby
+my_user_id = 'some-user-id-from-your-app'
+
+# Create an Individual Application
+application = Unit::IndividualApplication.create(
+    full_name: Unit::Types::FullName.new(first: 'John', last: 'Doe'),
+    email: 'individual@example.com',
+    ssn: rand(10**9).to_s.rjust(9, '0'),
+    phone: Unit::Types::Phone.new(country_code: '1', number: '5555555555'),
+    occupation: 'ArchitectOrEngineer',
+    address: Unit::Types::Address.new(
+        street: '123 Main St.',
+        city: 'Brooklyn',
+        state: 'NY',
+        postal_code: '11211',
+        country: 'US'
+    ),
+    date_of_birth: '2000-01-01',
+    tags: {
+      externalUserId: my_user_id
+    }
+)
+
+customer = application.customer
+
+deposit_account = Unit::DepositAccount.create(
+    deposit_product: 'checking',
+    customer: customer
+)
+
+debit_card = Unit::IndividualDebitCard.create(
+    idempotency_key: "debit-card-for-#{my_user_id}",
+    customer: customer,
+    account: deposit_account,
+    shipping_address: customer.address,
+    tags: { externalUserId: my_user_id }
+)
+```
+
+> [!TIP]
+>
+> Refer to the examples in `./spec/**` for further examples
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/test` to run the tests. You will also need UNIT_THEME_ID and UNIT_LANGUAGE_ID set in your environment. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, install dependencies:
 
-To install this gem onto your local machine, run `bundle exec rake install`.
+```bash
+$ bin/setup
+```
+
+Run the tests:
+
+```bash
+$ bin/test
+```
+
+For an interactive prompt to experiment with the gem:
+
+```bash
+$ bin/console
+```
+
+To install this gem onto your local machine:
+
+```bash
+$ bundle exec rake install
+```
 
 ## Releasing
 
@@ -53,12 +141,12 @@ Once your account is set up, the following operations will facilitate publishing
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/retirable/unit-ruby. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/retirable/unit-ruby.
+
+## Code of Conduct
+
+This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Code of Conduct](https://github.com/retirable/unit-ruby/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
-
-## Code of Conduct
-
-Everyone interacting in the Unit project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/retirable/unit-ruby/blob/master/CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ end
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You will also need UNIT_THEME_ID and UNIT_LANGUAGE_ID set in your environment. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/test` to run the tests. You will also need UNIT_THEME_ID and UNIT_LANGUAGE_ID set in your environment. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`.
 

--- a/bin/setup
+++ b/bin/setup
@@ -3,6 +3,12 @@ set -euo pipefail
 IFS=$'\n\t'
 set -vx
 
+# Copy .env.example to .env if .env doesn't exist
+if [ ! -f .env ] && [ -f .env.example ]; then
+  cp .env.example .env
+  echo "Created .env from .env.example"
+fi
+
 bundle install
 
-# Do any other automated setup that you need to do here
+echo "Setup complete"

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+bundle exec rspec "$@"

--- a/lib/unit-ruby/version.rb
+++ b/lib/unit-ruby/version.rb
@@ -1,3 +1,3 @@
 module Unit
-  VERSION = '0.12.2'
+  VERSION = '1.0.0'
 end

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Unit do
   it 'returns the correct version' do
-    expect(Unit::VERSION).to eq '0.12.2'
+    expect(Unit::VERSION).to eq '1.0.0'
   end
 end
 

--- a/unit-ruby.gemspec
+++ b/unit-ruby.gemspec
@@ -5,25 +5,18 @@ require 'unit-ruby/version'
 Gem::Specification.new do |spec|
   spec.name          = 'unit-ruby'
   spec.version       = Unit::VERSION
-  spec.authors       = ['Chloe Isacke', 'Ian Yamey']
-  spec.email         = ['chloe@retirable.com', 'ian@retirable.com']
+  spec.authors       = ['Chloe Isacke', 'Ian Yamey', 'Trevor Nelson']
+  spec.email         = ['chloe@retirable.com', 'ian@retirable.com', 'trevor@retirable.com']
 
   spec.summary       = 'A Ruby gem for communicating with the Unit API.'
   spec.homepage      = 'https://github.com/retirable/unit-ruby'
   spec.license       = 'MIT'
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = 'https://rubygems.org/'
-
-    spec.metadata['homepage_uri'] = spec.homepage
-    spec.metadata['source_code_uri'] = 'https://github.com/retirable/unit-ruby'
-    spec.metadata['changelog_uri'] = 'https://github.com/retirable/unit-ruby/blob/main/CHANGELOG.md'
-  else
-    raise 'RubyGems 2.0 or newer is required to protect against ' \
-          'public gem pushes.'
-  end
+  spec.metadata = {
+    'allowed_push_host' => 'https://rubygems.org/',
+    'source_code_uri' => 'https://github.com/retirable/unit-ruby',
+    'changelog_uri' => 'https://github.com/retirable/unit-ruby/blob/main/CHANGELOG.md'
+  }
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -34,15 +27,17 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activesupport'
-  spec.add_dependency 'faraday', '>= 2.0.1', '< 3'
-  spec.add_dependency 'faraday-retry'
+  spec.required_ruby_version = '>= 3.3'
 
-  spec.add_development_dependency 'dotenv', '~> 2.7.6'
-  spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_dependency 'activesupport', '~> 7'
+  spec.add_dependency 'faraday', '~> 2'
+  spec.add_dependency 'faraday-retry', '~> 2'
+
+  spec.add_development_dependency 'dotenv', '~> 2'
+  spec.add_development_dependency 'pry', '~> 0.15'
+  spec.add_development_dependency 'rake', '~> 13'
+  spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'rspec-file_fixtures', '~> 0.1.9'
-  spec.add_development_dependency 'rubocop', '~> 1.24.1'
+  spec.add_development_dependency 'rubocop', '~> 1'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
This PR prepares our v1.0.0 release

* Updates README
* Updates the code of conduct contact address
* Tighten up gemspec
  * Drop support for older versions of Ruby (we now only test on Ruby `3.3` and `3.4`)
  * Add @trevornelson to list of authors
  * Set clearer dependency version boundaries
* Adds `bin/test` script